### PR TITLE
Repo rename from pypyr-cli to pypyr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,7 @@ check out the `contribution guide <CONTRIBUTING.rst>`_.
 Bugs
 ====
 Well, you know. No one's perfect. Feel free to `create an issue
-<https://github.com/pypyr/pypyr-cli/issues/new>`_.
+<https://github.com/pypyr/pypyr/issues/new>`_.
 
 *******
 License
@@ -174,11 +174,11 @@ Copyright 2017 the pypyr contributors.
 
 .. |build-status| image:: https://api.shippable.com/projects/58efdfe130eb380700e559a6/badge?branch=master
                     :alt: build status
-                    :target: https://app.shippable.com/github/pypyr/pypyr-cli
+                    :target: https://app.shippable.com/github/pypyr/pypyr/
 
 .. |coverage| image:: https://api.shippable.com/projects/58efdfe130eb380700e559a6/coverageBadge?branch=master
                 :alt: coverage status
-                :target: https://app.shippable.com/github/pypyr/pypyr-cli
+                :target: https://app.shippable.com/github/pypyr/pypyr/
 
 .. |pypi| image:: https://badge.fury.io/py/pypyr.svg
                 :alt: pypi version

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.1
+current_version = 3.2.2
 
 [bdist_wheel]
 universal = 0
@@ -12,4 +12,3 @@ exclude_lines =
 
 [coverage:run]
 branch = True
-

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ import pypyr.version
 
 here = path.abspath(path.dirname(__file__))
 
-short_description = """task-runner cli to run pipelines defined in yaml"""
+short_description = (
+    "task-runner for automation pipelines defined in yaml. cli & api.")
 
 # Get the long description from the README file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
@@ -33,7 +34,14 @@ setup(
     long_description=long_description,
 
     # The project's main homepage.
-    url='https://github.com/pypyr/pypyr-cli',
+    url='https://pypyr.io',
+
+    project_urls={
+        'Documentation': 'https://pypyr.io/docs/',
+        'Source': 'https://github.com/pypyr/pypyr/',
+        'Release notes': 'https://pypyr.io/updates/releases/',
+        'Tracker': 'https://github.com/pypyr/pypyr/issues',
+    },
 
     # Author details
     author='Thomas Gaigher',
@@ -67,7 +75,7 @@ setup(
     ],
 
     # What does your project relate to?
-    keywords='devops pipeline runner',
+    keywords='task-runner,automation,devops,ci/cd,pipeline runner',
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
@@ -113,11 +121,7 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'console_scripts': [
-            'pypyr=pypyr.cli:main',
-            'pypyr-cli=pypyr.cli:main'
-        ],
-        'pypyr': [
-            'pypyr=pypyrcli'
+            'pypyr=pypyr.cli:main'
         ]
     },
 )


### PR DESCRIPTION
- Update documentation and pypi setup with new repo name.
- bump version to publish.