### PR TITLE
streamlined api entry-points

### DIFF
--- a/pypyr/log/logger.py
+++ b/pypyr/log/logger.py
@@ -15,7 +15,7 @@ def set_logging_config(log_level, handlers):
     module's output.
     """
     if log_level is None:
-        level = 25
+        level = NOTIFY
         format_string = '%(message)s'
     else:
         level = log_level
@@ -52,10 +52,26 @@ def set_up_notify_log_level():
     logging.getLoggerClass().notify = notify
 
 
-def set_root_logger(log_level, log_path=None):
+def set_root_logger(log_level=None, log_path=None):
     """Set the root logger 'pypyr'. Do this before you do anything else.
 
     Run once and only once at initialization.
+
+    log_level enumeration:
+    10=DEBUG
+    20=INFO
+    25=NOTIFY (default)
+    30=WARNING
+    40=ERROR
+    50=CRITICAL
+
+    < 10 gives full traceback on errors.
+
+    Args:
+        log_level (int): Log level. If not specified, defaults to 25 - NOTIFY.
+        log_path (path-like): File path+name. If specified, pypyr will append
+            logging output to this indefinitely growing file and to the
+            console.
     """
     handlers = []
 

--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -3,8 +3,7 @@
 Load modules dynamically, find things on file-system.
 
 Attributes:
-    working_dir (Path-like): Instance of WorkingDir. Holds the current working
-                             dir.
+    working_dir (WorkingDir): Global shared current working dir.
 """
 
 import importlib

--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -39,7 +39,7 @@ class WorkingDir():
             raise ValueError('working directory not set.')
         return self._cwd
 
-    def set_working_directory(self, working_directory):
+    def set_working_directory(self, working_directory=None):
         """Add working_directory to sys.paths.
 
         Defaults to cwd if working_directory is None.
@@ -118,7 +118,7 @@ def get_working_directory():
     return working_dir.get_working_directory()
 
 
-def set_working_directory(working_directory):
+def set_working_directory(working_directory=None):
     """Add working_directory to sys.paths.
 
     Really just a convenience wrapper for

--- a/pypyr/moduleloader.py
+++ b/pypyr/moduleloader.py
@@ -31,7 +31,7 @@ class WorkingDir():
         """Get current working directory.
 
         Return:
-            Path-like current working directory.
+            Path object for current working directory.
 
         Raises:
             ValueError: If set_working_directory wasn't called before this.
@@ -59,7 +59,7 @@ class WorkingDir():
         logger.debug("adding %s to sys.paths", working_directory)
         # sys path doesn't accept Path
         sys.path.append(str(working_directory))
-        self._cwd = working_directory
+        self._cwd = Path(working_directory)
 
         logger.debug("done")
 

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -28,8 +28,8 @@ def get_parsed_context(pipeline, context_in_args):
     dict and execute the get_parsed_context function on that module.
 
     Args:
-        pipeline: dict. Pipeline object.
-        context_in_args: list of string. Input arguments from console.
+        pipeline (dict): Pipeline object.
+        context_in_args (list of str): Input arguments from console.
 
     Returns:
         pypyr.context.Context() instance.
@@ -92,16 +92,16 @@ def main(
     Be aware that if you invoke this method, pypyr adds a NOTIFY - 25 custom
     log-level and notify() function to logging.
 
-    pipeline_name.yaml should be in the working_dir/pipelines/ directory.
+    pipeline_name.yaml should resolve from the working_dir directory.
 
     Args:
-        pipeline_name: string. Name of pipeline, sans .yaml at end.
-        pipeline_context_input: string. Initialize the pypyr context with this
-                                string.
-        working_dir: path. looks for ./pipelines and modules in this directory.
-        groups: list of str. step-group names to run in pipeline.
-        success_group: str. step-group name to run on success completion.
-        failure_group: str. step-group name to run on pipeline failure.
+        pipeline_name (str): Name of pipeline, sans .yaml at end.
+        pipeline_context_input (list of str): All the input arguments after
+            the pipeline name from console.
+        working_dir (path): Pipeline & module paths resolve from here.
+        groups: (list of str): Step-group names to run in pipeline.
+        success_group (str): Step-group name to run on success completion.
+        failure_group: (str): Step-group name to run on pipeline failure.
 
     Returns:
         None
@@ -132,10 +132,10 @@ def prepare_context(pipeline, context_in_args, context):
     """Prepare context for pipeline run.
 
     Args:
-        pipeline: dict. Dictionary representing the pipeline.
-        context_in_args: list of str. Args used to initialize context.
-        context: pypyr.context.Context. Merge any new context generated from
-                 context_in_string into this context instance.
+        pipeline (dict): Dictionary representing the pipeline.
+        context_in_args (list of str): Args used to initialize context.
+        context (pypyr.context.Context): Merge any new context generated from
+            context_in_args into this context instance.
 
     Returns:
         None. The context instance to use for the pipeline run is contained
@@ -175,8 +175,8 @@ def load_and_run_pipeline(pipeline_name,
 
     Args:
         pipeline_name (str): Name of pipeline, sans .yaml at end.
-        pipeline_context_input (str): Initialize the pypyr context with this
-                                 string.
+        pipeline_context_input (list of str): Args used to initialize context.
+            These go to the context_parser.
         context (pypyr.context.Context): Use if you already have a
                  Context object, such as if you are running a pipeline from
                  within a pipeline and you want to re-use the same context
@@ -247,12 +247,12 @@ def run_pipeline(pipeline,
     Args:
         pipeline (dict): Dictionary representing the pipeline.
         context (pypyr.context.Context): Reusable context object.
-        pipeline_context_input (str): Initialize the pypyr context with this
-                                string.
+        pipeline_context_input (list of str): Args used to initialize context.
+            These go to the context_parser.
         parse_input (bool): run context_parser in pipeline.
-        groups: list of str. step-group names to run in pipeline.
-        success_group: str. step-group name to run on success completion.
-        failure_group: str. step-group name to run on pipeline failure.
+        groups (list of str): step-group names to run in pipeline.
+        success_group (str): step-group name to run on success completion.
+        failure_group (str): step-group name to run on pipeline failure.
 
     Returns:
         None

--- a/pypyr/pypeloaders/fileloader.py
+++ b/pypyr/pypeloaders/fileloader.py
@@ -17,8 +17,8 @@ def get_pipeline_path(pipeline_name, working_directory):
     Then checks {pypyr install dir}/pipelines dir.
 
     Args:
-        pipeline_name: string. Name of pipeline to find
-        working_directory: string. Path in which to look for pipeline_name.yaml
+        pipeline_name (str): Name of pipeline to find
+        working_directory (Path): Path in which to look for pipeline_name.yaml
 
     Returns:
         Absolute path to the pipeline_name.yaml file
@@ -30,10 +30,9 @@ def get_pipeline_path(pipeline_name, working_directory):
     """
     logger.debug("starting")
 
-    # look for name.yaml in the pipelines/ sub-directory
     logger.debug("current directory is %s", working_directory)
 
-    cwd = Path(working_directory)
+    cwd = working_directory
 
     # look for cwd/{pipeline_name}.yaml
     pipeline_path = cwd.joinpath(f'{pipeline_name}.yaml')
@@ -82,10 +81,9 @@ def get_pipeline_definition(pipeline_name, working_dir):
     fileloader directory look-up sequence.
 
     Args:
-        pipeline_name: string. Name of pipeline. This will be the file-name of
-                       the pipeline - i.e {pipeline_name}.yaml
-        working_dir: path. Start looking in
-                           ./working_dir/pipeline_name.yaml
+        pipeline_name (str): Name of pipeline. This will be the file-name of
+                             the pipeline - i.e {pipeline_name}.yaml
+        working_dir (path): Start looking in ./working_dir/pipeline_name.yaml
 
     Returns:
         dict describing the pipeline, parsed from the pipeline yaml.
@@ -97,9 +95,8 @@ def get_pipeline_definition(pipeline_name, working_dir):
     """
     logger.debug("starting")
 
-    pipeline_path = get_pipeline_path(
-        pipeline_name=pipeline_name,
-        working_directory=working_dir)
+    pipeline_path = get_pipeline_path(pipeline_name=pipeline_name,
+                                      working_directory=working_dir)
 
     logger.debug("Trying to open pipeline at path %s", pipeline_path)
     try:

--- a/pypyr/steps/echo.py
+++ b/pypyr/steps/echo.py
@@ -24,11 +24,7 @@ def run_step(context):
 
     context.assert_key_exists('echoMe', __name__)
 
-    if isinstance(context['echoMe'], str):
-        val = context.get_formatted('echoMe')
-    else:
-        val = context['echoMe']
-
+    val = context.get_formatted('echoMe')
     logger.notify(val)
 
     logger.debug("done")

--- a/pypyr/steps/pype.py
+++ b/pypyr/steps/pype.py
@@ -1,5 +1,6 @@
 """pypyr step that runs another pipeline from within the current pipeline."""
 import logging
+import shlex
 from pypyr.context import Context
 from pypyr.errors import (ContextError,
                           ControlOfFlowInstruction,
@@ -202,7 +203,15 @@ def get_arguments(context):
             "pypyr.steps.pype 'args' in the 'pype' context item "
             "must be a dict.")
 
-    if args and 'useParentContext' not in pype:
+    pipe_arg_string = pype.get('pipeArg', None)
+    pipe_arg = shlex.split(pipe_arg_string) if pipe_arg_string else None
+
+    if pipe_arg_string and 'skipParse' not in pype:
+        skip_parse = False
+    else:
+        skip_parse = pype.get('skipParse', True)
+
+    if (args or pipe_arg_string) and 'useParentContext' not in pype:
         use_parent_context = False
     else:
         use_parent_context = pype.get('useParentContext', True)
@@ -217,8 +226,6 @@ def get_arguments(context):
             "leave off the useParentContext key and it'll default to False "
             "under the hood, or set it to False yourself if you keep it in.")
 
-    pipe_arg = pype.get('pipeArg', None)
-    skip_parse = pype.get('skipParse', True)
     raise_error = pype.get('raiseError', True)
     loader = pype.get('loader', None)
     groups = pype.get('groups', None)

--- a/pypyr/steps/pype.py
+++ b/pypyr/steps/pype.py
@@ -99,16 +99,23 @@ def run_step(context):
                 logger.debug("writing args into parent context...")
                 context.update(args)
 
-            pipelinerunner.load_and_run_pipeline(
-                pipeline_name=pipeline_name,
-                pipeline_context_input=pipe_arg,
-                context=context,
-                parse_input=not skip_parse,
-                loader=loader,
-                groups=step_groups,
-                success_group=success_group,
-                failure_group=failure_group
-            )
+            try:
+                og_pipeline_name = context.pipeline_name
+                context.pipeline_name = pipeline_name
+
+                pipelinerunner.load_and_run_pipeline(
+                    pipeline_name=pipeline_name,
+                    pipeline_context_input=pipe_arg,
+                    context=context,
+                    parse_input=not skip_parse,
+                    loader=loader,
+                    groups=step_groups,
+                    success_group=success_group,
+                    failure_group=failure_group
+                )
+            finally:
+                context.pipeline_name = og_pipeline_name
+
         else:
             logger.info("pyping %s, without parent context.", pipeline_name)
 

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.2.0'
+__version__ = '4.3.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.0
+current_version = 4.3.0
 
 [bumpversion:file:pypyr/version.py]
 

--- a/tests/arbpack/naivefileloader.py
+++ b/tests/arbpack/naivefileloader.py
@@ -1,10 +1,8 @@
-"""Simple file loader for integration testing."""
-from pathlib import Path
+"""Naive file loader for integration testing."""
 import pypyr.yaml
 
 
 def get_pipeline_definition(pipeline_name, working_dir):
     """Simplified file loader for integration testing."""
-    with open(Path(working_dir).joinpath(f'{pipeline_name}.yaml')
-              ) as yaml_file:
+    with open(working_dir.joinpath(f'{pipeline_name}.yaml')) as yaml_file:
         return pypyr.yaml.get_pipeline_yaml(yaml_file)

--- a/tests/arbpack/naivefileloader.py
+++ b/tests/arbpack/naivefileloader.py
@@ -1,0 +1,10 @@
+"""Simple file loader for integration testing."""
+from pathlib import Path
+import pypyr.yaml
+
+
+def get_pipeline_definition(pipeline_name, working_dir):
+    """Simplified file loader for integration testing."""
+    with open(Path(working_dir).joinpath(f'{pipeline_name}.yaml')
+              ) as yaml_file:
+        return pypyr.yaml.get_pipeline_yaml(yaml_file)

--- a/tests/integration/pypyr/pipelinerunner_int_test.py
+++ b/tests/integration/pypyr/pipelinerunner_int_test.py
@@ -1,18 +1,259 @@
 """pipelinerunner.py integration tests."""
-import os
-import pypyr.pipelinerunner
-# ------------------------- integration---------------------------------------#
+import logging
+from pathlib import Path
+import pytest
+from unittest.mock import call
+from pypyr import pipelinerunner
+from pypyr.cache import pipelinecache
+from pypyr.errors import KeyNotInContextError
+from tests.common.utils import patch_logger
+
+working_dir_tests = Path(Path.cwd(), 'tests')
 
 
-def test_pipeline_runner_main():
+@pytest.fixture
+def pipeline_cache_reset():
+    """Invoke for every test function in the module."""
+    pipelinecache.pipeline_cache.clear()
+    yield
+    pipelinecache.pipeline_cache.clear()
+
+# region smoke
+
+
+def test_pipeline_runner_main(pipeline_cache_reset):
     """Smoke test for pipeline runner main.
 
     Strictly speaking this is an integration test, not a unit test.
     """
-    working_dir = os.path.join(
-        os.getcwd(),
-        'tests')
-    pypyr.pipelinerunner.main(pipeline_name='smoke',
-                              pipeline_context_input=None,
-                              working_dir=working_dir)
-# ------------------------- integration---------------------------------------#
+    pipelinerunner.main(pipeline_name='smoke',
+                        pipeline_context_input=None,
+                        working_dir=working_dir_tests)
+# endregion smoke
+
+# region main
+
+
+def test_pipeline_runner_main_all(pipeline_cache_reset):
+    """Run main with all arguments as expected."""
+    expected_notify_output = ['sg1', 'sg1.2', 'success_handler']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        pipelinerunner.main(
+            pipeline_name='pipelines/api/main-all',
+            pipeline_context_input=['A', 'B', 'C'],
+            working_dir=working_dir_tests,
+            groups=['sg1'],
+            success_group='sh',
+            failure_group='fh',
+            loader='arbpack.naivefileloader')
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_all_with_failure(pipeline_cache_reset):
+    """Run main with all arguments as expected with runtime error."""
+    expected_notify_output = ['sg2', 'success_handler', 'fh']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        with pytest.raises(ValueError) as err:
+            pipelinerunner.main(
+                pipeline_name='pipelines/api/main-all',
+                pipeline_context_input=['A', 'B', 'C', 'raise on sh'],
+                working_dir=working_dir_tests,
+                groups=['sg2'],
+                success_group='sh',
+                failure_group='fh',
+                loader='arbpack.naivefileloader')
+
+    assert str(err.value) == "err from sh"
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_minimal():
+    """Run main with minimal arguments as expected."""
+    expected_notify_output = ['steps', 'argList==None', 'on_success']
+
+    # working_dir will default to repo root rather than test root
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        pipelinerunner.main('tests/pipelines/api/main-all')
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_with_failure():
+    """Run main with failure argument as expected."""
+    expected_notify_output = ['sg3', 'fh']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        with pytest.raises(ValueError) as err:
+            pipelinerunner.main(
+                pipeline_name='tests/pipelines/api/main-all',
+                groups=['sg3'],
+                failure_group='fh')
+
+    assert str(err.value) == "err from sg3"
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_minimal_with_failure_handled():
+    """Run main minimal with failure argument as expected."""
+    expected_notify_output = ['steps', 'on_success', 'on_failure']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        pipelinerunner.main(
+            pipeline_name='tests/pipelines/api/main-all',
+            pipeline_context_input=['A', 'B', 'C', 'raise on success'])
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_with_failure_handled():
+    """Run main with failure argument as expected."""
+    expected_notify_output = ['sg3', 'on_failure']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        pipelinerunner.main(pipeline_name='tests/pipelines/api/main-all',
+                            groups=['sg3'],
+                            failure_group='on_failure')
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+# endregion main
+
+# region main_with_context
+
+
+def test_pipeline_runner_main_with_context_all(pipeline_cache_reset):
+    """Run main with context with all arguments as expected."""
+    expected_notify_output = ['sg1', 'sg1.2', 'success_handler']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        out = pipelinerunner.main_with_context(
+            pipeline_name='pipelines/api/main-all',
+            dict_in={'argList': ['A', 'B', 'C']},
+            working_dir=working_dir_tests,
+            groups=['sg1'],
+            success_group='sh',
+            failure_group='fh',
+            loader='arbpack.naivefileloader')
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+    assert out.pipeline_name == 'pipelines/api/main-all'
+    assert out.working_dir == working_dir_tests
+    assert out == {'argList': ['A', 'B', 'C'], 'set_in_pipe': 123}
+
+
+def test_pipeline_runner_main_with_context_all_with_failure(
+        pipeline_cache_reset):
+    """Run main with context - all arguments as expected with runtime error."""
+    expected_notify_output = ['sg2', 'success_handler', 'fh']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        with pytest.raises(ValueError) as err:
+            pipelinerunner.main_with_context(
+                pipeline_name='pipelines/api/main-all',
+                dict_in={'argList': ['A', 'B', 'C', 'raise on sh']},
+                working_dir=working_dir_tests,
+                groups=['sg2'],
+                success_group='sh',
+                failure_group='fh',
+                loader='arbpack.naivefileloader')
+
+    assert str(err.value) == "err from sh"
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_with_context_minimal():
+    """Run main with context with minimal arguments as expected."""
+    # Not having argList==None proves context_parser didn't run.
+    expected_notify_output = ['steps', 'argList not exist', 'on_success']
+
+    # working_dir will default to repo root rather than test root
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        out = pipelinerunner.main_with_context('tests/pipelines/api/main-all')
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+    assert out.pipeline_name == 'tests/pipelines/api/main-all'
+    assert out.working_dir == Path.cwd()
+    assert out == {'set_in_pipe': 456}
+    # somewhat arbitrary check if behaves like Context()
+    out.assert_key_has_value('set_in_pipe', 'caller')
+
+
+def test_pipeline_runner_main_with_context_with_failure():
+    """Run main with context with failure argument as expected."""
+    expected_notify_output = ['sg3', 'fh']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        with pytest.raises(ValueError) as err:
+            pipelinerunner.main_with_context(
+                pipeline_name='tests/pipelines/api/main-all',
+                groups=['sg3'],
+                failure_group='fh')
+
+    assert str(err.value) == "err from sg3"
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+
+
+def test_pipeline_runner_main_with_context_minimal_with_failure_handled():
+    """Run main with context minimal with failure argument as expected."""
+    expected_notify_output = ['steps', 'on_success', 'on_failure']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        out = pipelinerunner.main_with_context(
+            pipeline_name='tests/pipelines/api/main-all',
+            dict_in={'argList': ['A', 'B', 'C', 'raise on success']})
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+    assert out.pipeline_name == 'tests/pipelines/api/main-all'
+    assert out.working_dir == Path.cwd()
+
+    assert len(out) == 4
+    assert out['argList'] == ['A', 'B', 'C', 'raise on success']
+    assert out['set_in_pipe'] == 456
+    assert out['pycode'] == "raise ValueError('err from on_success')"
+
+    assert len(out['runErrors']) == 1
+    out_run_error = out['runErrors'][0]
+    assert out_run_error
+    assert out_run_error['col'] == 5
+    assert out_run_error['customError'] == {}
+    assert out_run_error['description'] == 'err from on_success'
+    assert repr(out_run_error['exception']) == repr(ValueError(
+        'err from on_success'))
+    assert out_run_error['line'] == 74
+    assert out_run_error['name'] == 'ValueError'
+    assert out_run_error['step'] == 'pypyr.steps.py'
+    assert out_run_error['swallowed'] is False
+    # somewhat arbitrary check if behaves like Context()
+    out.assert_key_has_value('set_in_pipe', 'caller')
+
+
+def test_pipeline_runner_main_with_context_with_failure_handled():
+    """Run main with context with failure argument as expected."""
+    expected_notify_output = ['sg3', 'on_failure']
+    with patch_logger('pypyr.steps.echo', logging.NOTIFY) as mock_log:
+        out = pipelinerunner.main_with_context(
+            pipeline_name='tests/pipelines/api/main-all',
+            groups=['sg3'],
+            failure_group='on_failure')
+
+    assert mock_log.mock_calls == [call(v) for v in expected_notify_output]
+    assert out.pipeline_name == 'tests/pipelines/api/main-all'
+    assert out.working_dir == Path.cwd()
+
+    assert len(out) == 2
+    assert out['pycode'] == "raise ValueError('err from sg3')"
+
+    assert len(out['runErrors']) == 1
+    out_run_error = out['runErrors'][0]
+    assert out_run_error
+    assert out_run_error['col'] == 5
+    assert out_run_error['customError'] == {}
+    assert out_run_error['description'] == 'err from sg3'
+    assert repr(out_run_error['exception']) == repr(ValueError('err from sg3'))
+    assert out_run_error['line'] == 50
+    assert out_run_error['name'] == 'ValueError'
+    assert out_run_error['step'] == 'pypyr.steps.py'
+    assert out_run_error['swallowed'] is False
+
+    # somewhat arbitrary check if behaves like Context()
+    with pytest.raises(KeyNotInContextError) as err:
+        out.assert_key_has_value('set_in_pipe', 'arbcaller')
+
+    assert str(err.value) == ("context['set_in_pipe'] doesn't exist. It must "
+                              "exist for arbcaller.")
+
+# endregion main_with_context

--- a/tests/integration/pypyr/pype/pype_int_test.py
+++ b/tests/integration/pypyr/pype/pype_int_test.py
@@ -1,0 +1,13 @@
+"""Pype integration tests. Pipelines in ./tests/pipelines/pype."""
+import tests.common.pipeline_runner as test_pipe_runner
+# ------------------------- runErrors ----------------------------------------#
+
+
+def test_pype_pipearg_int():
+    """Pype parses pypeArg string and accessible in child."""
+    pipename = 'pype/pipeargs'
+    test_pipe_runner.assert_pipeline_notify_output_is(pipename, ['A',
+                                                                 'B',
+                                                                 'C',
+                                                                 'C',
+                                                                 'D'])

--- a/tests/integration/pypyr/pype/pype_int_test.py
+++ b/tests/integration/pypyr/pype/pype_int_test.py
@@ -11,3 +11,11 @@ def test_pype_pipearg_int():
                                                                  'C',
                                                                  'C',
                                                                  'D'])
+
+
+def test_pype_err_int():
+    """Pype calls handles error with pipeline_name correctly."""
+    pipename = 'pype/pipeerr'
+    test_pipe_runner.assert_pipeline_notify_output_is(pipename, ['A',
+                                                                 'B',
+                                                                 'C'])

--- a/tests/pipelines/api/main-all.yaml
+++ b/tests/pipelines/api/main-all.yaml
@@ -1,0 +1,87 @@
+context_parser: pypyr.parser.list
+
+steps:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: steps
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        set_in_pipe: 456
+  - name: pypyr.steps.echo
+    run: !py "'argList' not in locals()"
+    in:
+      echoMe: argList not exist
+  - name: pypyr.steps.stopstepgroup
+    run: !py "'argList' not in locals()"
+  - name: pypyr.steps.echo
+    run: !py not argList 
+    in:
+      echoMe: argList==None
+
+sg1:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: sg1
+  - name: pypyr.steps.assert
+    in:
+      assert: '{argList}'
+      equals:
+        - A
+        - B
+        - C
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        set_in_pipe: 123
+  - name: pypyr.steps.echo
+    in:
+      echoMe: sg1.2
+
+sg2:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: sg2
+
+sg3:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: sg3
+  - name: pypyr.steps.py
+    in:
+      pycode: raise ValueError('err from sg3')
+
+sh:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: success_handler
+  - name: pypyr.steps.py
+    run: !py argList and 'raise on sh' in argList
+    in:
+      pycode: raise ValueError('err from sh')
+
+fh:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: fh
+
+on_success:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: on_success
+  - name: pypyr.steps.stopstepgroup
+    run: !py "'argList' not in locals()"
+  - name: pypyr.steps.py
+    run: !py argList and 'raise on success' in argList
+    in:
+      pycode: raise ValueError('err from on_success')
+
+on_failure:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: on_failure
+  - pypyr.steps.stop
+  - name: pypyr.steps.assert
+    comment: ensure unreachable
+    in:
+      assert: False

--- a/tests/pipelines/pype/childpipeargs.yaml
+++ b/tests/pipelines/pype/childpipeargs.yaml
@@ -18,3 +18,6 @@ steps:
   - name: pypyr.steps.echo
     in:
       echoMe: B
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/childpipeargs'

--- a/tests/pipelines/pype/childpipeargs.yaml
+++ b/tests/pipelines/pype/childpipeargs.yaml
@@ -1,0 +1,20 @@
+context_parser: pypyr.parser.keyvaluepairs
+steps:
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{parent}'
+        equals: A
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{b}'
+        equals: set in pipe arg
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{c}'
+        equals: arbvalue
+  - name: pypyr.steps.echo
+    in:
+      echoMe: B

--- a/tests/pipelines/pype/childpipeargs_noparent.yaml
+++ b/tests/pipelines/pype/childpipeargs_noparent.yaml
@@ -13,6 +13,9 @@ steps:
       assert:
         this: '{c}'
         equals: arbvalue
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/childpipeargs_noparent'
   - name: pypyr.steps.contextsetf
     in:
       contextSetf:

--- a/tests/pipelines/pype/childpipeargs_noparent.yaml
+++ b/tests/pipelines/pype/childpipeargs_noparent.yaml
@@ -1,0 +1,24 @@
+context_parser: pypyr.parser.keyvaluepairs
+steps:
+  - name: pypyr.steps.assert
+    in:
+      assert: !py "'parent' not in locals()"
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{b}'
+        equals: set in pipe arg
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{c}'
+        equals: arbvalue
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        parent: parent set in child
+        b: b set in child
+        c: c set in child
+  - name: pypyr.steps.echo
+    in:
+      echoMe: C

--- a/tests/pipelines/pype/pipeargs.yaml
+++ b/tests/pipelines/pype/pipeargs.yaml
@@ -1,0 +1,90 @@
+steps:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: A
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        parent: A
+  - name: pypyr.steps.pype
+    in:
+      pype:
+        name: pype/childpipeargs
+        pipeArg: b="set in pipe arg" c=arbvalue
+        useParentContext: True
+  # explicit useParentContext = True
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{parent}'
+        equals: A
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{b}'
+        equals: set in pipe arg
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{c}'
+        equals: arbvalue
+
+
+  - pypyr.steps.contextclearall
+  # implied useParentContext = False
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        parent: A
+  - name: pypyr.steps.pype
+    in:
+      pype:
+        name: pype/childpipeargs_noparent
+        pipeArg: b="set in pipe arg" c=arbvalue
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{parent}'
+        equals: A
+  - name: pypyr.steps.assert
+    in:
+      assert: !py "('b' not in locals()) and ('c' not in locals())"
+
+  - pypyr.steps.contextclearall
+  # explicit useParentContext = False AND out set
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        parent: Aonset
+  - name: pypyr.steps.pype
+    in:
+      pype:
+        name: pype/childpipeargs_noparent
+        pipeArg: b="set in pipe arg" c=arbvalue
+        skipParse: False
+        useParentContext: False
+        out:
+          'd': 'b'
+          'e': 'c' 
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{parent}'
+        equals: Aonset
+  - name: pypyr.steps.assert
+    in:
+      assert: !py "('b' not in locals()) and ('c' not in locals())"
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{d}'
+        equals: b set in child
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{e}'
+        equals: c set in child
+
+  - name: pypyr.steps.echo
+    in:
+      echoMe: D

--- a/tests/pipelines/pype/pipeargs.yaml
+++ b/tests/pipelines/pype/pipeargs.yaml
@@ -6,6 +6,9 @@ steps:
     in:
       contextSetf:
         parent: A
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeargs'
   - name: pypyr.steps.pype
     in:
       pype:
@@ -13,6 +16,9 @@ steps:
         pipeArg: b="set in pipe arg" c=arbvalue
         useParentContext: True
   # explicit useParentContext = True
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeargs'
   - name: pypyr.steps.assert
     in:
       assert:
@@ -36,11 +42,17 @@ steps:
     in:
       contextSetf:
         parent: A
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeargs'
   - name: pypyr.steps.pype
     in:
       pype:
         name: pype/childpipeargs_noparent
         pipeArg: b="set in pipe arg" c=arbvalue
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeargs'
   - name: pypyr.steps.assert
     in:
       assert:
@@ -56,6 +68,9 @@ steps:
     in:
       contextSetf:
         parent: Aonset
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeargs'
   - name: pypyr.steps.pype
     in:
       pype:
@@ -66,6 +81,9 @@ steps:
         out:
           'd': 'b'
           'e': 'c' 
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeargs'
   - name: pypyr.steps.assert
     in:
       assert:

--- a/tests/pipelines/pype/pipeerr.yaml
+++ b/tests/pipelines/pype/pipeerr.yaml
@@ -1,0 +1,23 @@
+steps:
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeerr'
+
+  - name: pypyr.steps.echo
+    in:
+      echoMe: A
+
+  - name: pypyr.steps.pype
+    swallow: True
+    in:
+      echoMe: B
+      pype:
+        name: pype/pipeerr_child
+
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeerr'
+  
+  - name: pypyr.steps.echo
+    in:
+      echoMe: C

--- a/tests/pipelines/pype/pipeerr_child.yaml
+++ b/tests/pipelines/pype/pipeerr_child.yaml
@@ -1,0 +1,14 @@
+steps:
+  - name: pypyr.steps.py
+    in:
+      pycode: assert context.pipeline_name == 'pype/pipeerr_child'
+
+  - pypyr.steps.echo
+
+  - name: pypyr.steps.assert
+    in:
+      assert: False
+
+  - name: pypyr.steps.echo
+    in:
+      echoMe: UNREACHABLE

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -41,6 +41,40 @@ def test_main_pass_with_sysargv_context_positional():
     )
 
 
+def test_main_pass_with_sysargv_single_group():
+    """Invoke from cli sets sys.argv, check assigns correctly to group."""
+    arg_list = ['pypyr',
+                'blah',
+                'ctx string',
+                '--loglevel',
+                '50',
+                '--dir',
+                'dir here',
+                '--groups',
+                'group1',
+                '--success',
+                'sg',
+                '--failure',
+                'f g']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            with patch('pypyr.log.logger.set_root_logger') as mock_logger:
+                pypyr.cli.main()
+
+    mock_logger.assert_called_once_with(log_level=50,
+                                        log_path=None)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input=['ctx string'],
+        working_dir='dir here',
+        groups=['group1'],
+        success_group='sg',
+        failure_group='f g'
+    )
+
+
 def test_main_pass_with_sysargv_context_multiple_positional():
     """Multiple positional arguments."""
     arg_list = ['pypyr',

--- a/tests/unit/pypyr/cli_test.py
+++ b/tests/unit/pypyr/cli_test.py
@@ -41,6 +41,45 @@ def test_main_pass_with_sysargv_context_positional():
     )
 
 
+def test_main_pass_with_sysargv_context_multiple_positional():
+    """Multiple positional arguments."""
+    arg_list = ['pypyr',
+                'blah',
+                'ctx string',
+                'arg 2',
+                'arg 3',
+                'arg4=hello',
+                '--loglevel',
+                '50',
+                '--dir',
+                'dir here',
+                '--groups',
+                'group1',
+                'group 2',
+                'group3',
+                '--success',
+                'sg',
+                '--failure',
+                'f g']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            with patch('pypyr.log.logger.set_root_logger') as mock_logger:
+                pypyr.cli.main()
+
+    mock_logger.assert_called_once_with(log_level=50,
+                                        log_path=None)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input=['ctx string', 'arg 2', 'arg 3', 'arg4=hello'],
+        working_dir='dir here',
+        groups=['group1', 'group 2', 'group3'],
+        success_group='sg',
+        failure_group='f g'
+    )
+
+
 def test_main_pass_with_sysargv_context_positional_log_alias():
     """Invoke from cli sets sys.argv with log alias."""
     arg_list = ['pypyr',
@@ -120,6 +159,36 @@ def test_main_pass_with_sysargv_context_positional_flags_last():
     mock_pipeline_main.assert_called_once_with(
         pipeline_name='blah',
         pipeline_context_input=['ctx string'],
+        working_dir='dir here',
+        groups=None,
+        success_group=None,
+        failure_group=None
+    )
+
+
+def test_main_pass_with_sysargv_context_multiple_positional_flags_last():
+    """Check assigns correctly to multiple args when positional last."""
+    arg_list = ['pypyr',
+                '--loglevel',
+                '50',
+                '--dir',
+                'dir here',
+                'blah',
+                'ctx string',
+                'arb 2',
+                'arb3=arbvalue']
+
+    with patch('sys.argv', arg_list):
+        with patch('pypyr.pipelinerunner.main') as mock_pipeline_main:
+            with patch('pypyr.log.logger.set_root_logger') as mock_logger:
+                pypyr.cli.main()
+
+    mock_logger.assert_called_once_with(log_level=50,
+                                        log_path=None)
+
+    mock_pipeline_main.assert_called_once_with(
+        pipeline_name='blah',
+        pipeline_context_input=['ctx string', 'arb 2', 'arb3=arbvalue'],
         working_dir='dir here',
         groups=None,
         success_group=None,

--- a/tests/unit/pypyr/log/logger_test.py
+++ b/tests/unit/pypyr/log/logger_test.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 import pypyr.log.logger
 from tests.common.utils import patch_logger
 
+# region set_root_logger
+
 
 def test_logger_with_console_handler():
     """Root logger instantiates with just the console handler."""
@@ -17,6 +19,20 @@ def test_logger_with_console_handler():
         '%(asctime)s %(levelname)s:%(name)s:%(funcName)s: %(message)s')
     assert kwargs['datefmt'] == '%Y-%m-%d %H:%M:%S'
     assert kwargs['level'] == 10
+    assert len(kwargs['handlers']) == 1
+    assert isinstance(kwargs['handlers'][0], logging.StreamHandler)
+
+
+def test_logger_with_defaults():
+    """Root logger instantiates with no arguments passed."""
+    with patch.object(logging, 'basicConfig') as mock_logger:
+        pypyr.log.logger.set_root_logger()
+
+    mock_logger.assert_called_once()
+    args, kwargs = mock_logger.call_args
+    assert kwargs['format'] == '%(message)s'
+    assert kwargs['datefmt'] == '%Y-%m-%d %H:%M:%S'
+    assert kwargs['level'] == 25
     assert len(kwargs['handlers']) == 1
     assert isinstance(kwargs['handlers'][0], logging.StreamHandler)
 
@@ -41,7 +57,7 @@ def test_logger_with_file_and_console_handler():
     assert isinstance(kwargs['handlers'][1], logging.FileHandler)
 
 
-def test_notice_log_level_available():
+def test_notify_log_level_available():
     """Notify log level added."""
     # actually redundant, coz ./conftest.py actually already calls
     # set_up_notify_log_level. Might as well test re-entrancy then, thus:
@@ -58,14 +74,11 @@ def test_notice_log_level_available():
 
     mock_logger_notify.assert_called_once_with("Arb message: arb value")
 
-# ----------------------- set_logging_config ----------------------------------
-
 
 def test_set_logging_log_level_none():
     """Level None should default to simplified log output."""
-    log_path = None
     with patch.object(logging, 'basicConfig') as mock_logger:
-        pypyr.log.logger.set_root_logger(None, log_path)
+        pypyr.log.logger.set_root_logger(None, None)
 
     mock_logger.assert_called_once()
     args, kwargs = mock_logger.call_args
@@ -91,4 +104,4 @@ def test_set_logging_log_level_25():
     assert len(kwargs['handlers']) == 1
     assert isinstance(kwargs['handlers'][0], logging.StreamHandler)
 
-# ----------------------- END set_logging_config ------------------------------
+# endregion set_root_logger

--- a/tests/unit/pypyr/moduleloader_test.py
+++ b/tests/unit/pypyr/moduleloader_test.py
@@ -96,7 +96,23 @@ def test_get_module_in_package_pass():
 
 # ------------------------- get_module ---------------------------------------#
 
-# ------------------------- set_working_dir ----------------------------------#
+# region WorkingDir
+
+
+def test_working_dir_set_default():
+    """Set working dir to cwd if None."""
+    w = pypyr.moduleloader.WorkingDir()
+    w.set_working_directory(None)
+    assert w.get_working_directory() == Path.cwd()
+
+
+def test_working_dir_get_before_set():
+    """Get working dir before set raises."""
+    with pytest.raises(ValueError) as err:
+        w = pypyr.moduleloader.WorkingDir()
+        w.get_working_directory()
+
+    assert str(err.value) == 'working directory not set.'
 
 
 def test_set_working_dir():
@@ -107,4 +123,4 @@ def test_set_working_dir():
     assert p in sys.path
     sys.path.remove(p)
 
-# ------------------------- set_working_dir ----------------------------------#
+# endregion WorkingDir

--- a/tests/unit/pypyr/moduleloader_test.py
+++ b/tests/unit/pypyr/moduleloader_test.py
@@ -100,10 +100,28 @@ def test_get_module_in_package_pass():
 
 
 def test_working_dir_set_default():
+    """Set working dir to cwd if not specified."""
+    w = pypyr.moduleloader.WorkingDir()
+    w.set_working_directory()
+
+    cwd = Path.cwd()
+    assert w.get_working_directory() == cwd
+
+    cwd = str(cwd)
+    assert cwd in sys.path
+    sys.path.remove(cwd)
+
+
+def test_working_dir_set_explicit_none():
     """Set working dir to cwd if None."""
     w = pypyr.moduleloader.WorkingDir()
     w.set_working_directory(None)
-    assert w.get_working_directory() == Path.cwd()
+
+    cwd = Path.cwd()
+    assert w.get_working_directory() == cwd
+    cwd = str(cwd)
+    assert cwd in sys.path
+    sys.path.remove(cwd)
 
 
 def test_working_dir_get_before_set():

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -1,5 +1,6 @@
 """pipelinerunner.py unit tests."""
 import logging
+from pathlib import Path
 import pytest
 from unittest.mock import call, patch
 from pypyr.cache.loadercache import pypeloader_cache
@@ -833,7 +834,7 @@ def test_empty_loader_set_up_to_default(mock_get_pipeline_definition,
 
     mock_get_pipeline_definition.assert_called_once_with(
         pipeline_name='arb pipe',
-        working_dir='arb/dir'
+        working_dir=Path('arb/dir')
     )
     mock_run_pipeline.assert_called_once_with(
         context={},
@@ -864,7 +865,7 @@ def test_arb_loader(mock_run_pipeline):
         context={},
         parse_input=True,
         pipeline={'pipeline_name': 'arb pipe',
-                  'working_dir': 'tests'},
+                  'working_dir': Path('tests')},
         pipeline_context_input='arb context input',
         groups=None,
         success_group=None,


### PR DESCRIPTION
- Streamline main entrypoint API. close #201.
  - `main()` allows consumer to set pype loader, rather than having to drop further down into api to load_and_run_pipeline()
  - new `main_with_context()` to input dict to initialise context, and bypass context_parser entirely. Also returns the `Context` object after pipeline run completes.
  - make all non-essential args optional to allow minimal calls to main entrypoint without having to add `optional=None` style inputs.
  - This is fully backwards compatible.
- `pypyr.steps.pype`
  - defaults `useParentContext` to `False` is `pipeArgs` specified.
  - `pipeArgs` shlex-es input string
  - set `pipeline_name` on child pipeline rather than use parent pipeline name
- `working_dir` uses `Path` object rather than string
- `pypyr.steps.echo` remove redundant string check. 