### PR TITLE
pypyr.steps.pyimport.

### DIFF
--- a/pypyr/cache/namespacecache.py
+++ b/pypyr/cache/namespacecache.py
@@ -1,0 +1,47 @@
+"""Global cache for namespace imports.
+
+Attributes:
+    pystring_namespace_cache: global instance of the namespace cache for
+        PyString expressions. Use this attribute to access the cache from
+        elsewhere.
+"""
+import logging
+from sys import intern
+from pypyr.cache.cache import Cache
+from pypyr.moduleloader import ImportVisitor
+
+
+logger = logging.getLogger(__name__)
+
+
+class NamespaceCache(Cache):
+    """Cache of namespace dictionaries.
+
+    Parse source string for python import statements using AST Visitor.
+    """
+
+    def get_namespace(self, source):
+        """Get cached namespace. Adds to cache if not exist.
+
+        Args:
+            source (str): String with python 'import x.y'/'from x import y'
+                statements.
+
+        Returns:
+            Namespace dictionary of imported references.
+        """
+        logger.debug("starting")
+
+        # source can be relatively long.
+        # interning means cache dict compare obj id rather than full str parse
+        interned_source = intern(source)
+        namespace = self.get(
+            interned_source,
+            lambda: ImportVisitor().get_namespace(interned_source))
+
+        logger.debug("done")
+        return namespace
+
+
+# global instance of the cache. use this to access the cache from elsewhere.
+pystring_namespace_cache = NamespaceCache()

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -16,7 +16,7 @@ from pypyr.utils import expressions, poll
 # use pypyr logger to ensure loglevel is set correctly
 logger = logging.getLogger(__name__)
 
-# ------------------------ custom yaml tags -----------------------------------
+# region custom yaml tags
 
 
 class SpecialTagDirective:
@@ -199,7 +199,9 @@ class PyString(SpecialTagDirective):
     def get_value(self, context):
         """Run python eval on the input string."""
         if self.value:
-            return expressions.eval_string(self.value, context)
+            return expressions.eval_string(self.value,
+                                           context.pystring_globals,
+                                           context)
         else:
             # Empty input raises cryptic EOF syntax err, this more human
             # friendly
@@ -230,7 +232,7 @@ class SicString(SpecialTagDirective):
         """Simply return the string as is, the whole point of a sic string."""
         return self.value
 
-# ------------------------ END custom yaml tags -------------------------------
+# endregion custom yaml tags
 
 
 class Step:

--- a/pypyr/steps/contextclearall.py
+++ b/pypyr/steps/contextclearall.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_step(context):
-    """Wipe the entire context.
+    """Wipe the entire context, including the pyimport namespace.
 
     Args:
         Context is a dictionary or dictionary-like.
@@ -15,6 +15,8 @@ def run_step(context):
     logger.debug("started")
 
     context.clear()
-    logger.info("Context wiped. New context size: %s", len(context))
+    context.pystring_globals.clear()
+    logger.info("context & py imports wiped. New context size: %s",
+                len(context))
 
     logger.debug("done")

--- a/pypyr/steps/pyimport.py
+++ b/pypyr/steps/pyimport.py
@@ -1,0 +1,54 @@
+"""pypyr step that imports to the namespace for PyString.
+
+Make Python stdlib or your own code available to any PyString in the pipeline.
+
+Only supports absolute imports, not relative.
+
+Supports python import syntax like:
+    import x
+    import x as y
+
+    import x.y
+    import x.y as z
+
+    from x import y
+    from x import y as z
+
+    from x import y, z
+    from a.b import c as d, e as f
+"""
+import logging
+from pypyr.cache.namespacecache import pystring_namespace_cache
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Import modules, classes or functions for PyString expressions.
+
+    Args:
+        context (pypyr.context.Context):
+            Context is a dictionary or dictionary-like.
+            Context must contain key 'pyimport'
+            The value of pyimport is a string containing python import
+            statements.
+    """
+    logger.debug("started")
+    context.assert_key_has_value(key='pyImport', caller=__name__)
+
+    # block yaml style could be LiteralScalarString, which is not hashable for
+    # cache key. Explicitly make a string.
+    source = str(context['pyImport'])
+
+    namespace = pystring_namespace_cache.get_namespace(source)
+    # len safe coz get_namespace returns {}, not None.
+    logger.debug("imported %s objects to merge into PyString namespace",
+                 len(namespace))
+
+    context.pystring_globals.update(namespace)
+
+    # pystring_globals initialized to {} on Context init, so len() is safe.
+    logger.debug("PyString namespace now contains %s objects.",
+                 len(context.pystring_globals))
+
+    logger.debug("done")

--- a/pypyr/utils/expressions.py
+++ b/pypyr/utils/expressions.py
@@ -1,7 +1,7 @@
 """Utility functions for evaluating expressions."""
 
 
-def eval_string(input_string, locals):
+def eval_string(input_string, globals, locals):
     """Dynamically evaluates the input_string expression.
 
     This provides dynamic python eval of an input expression. The return is
@@ -30,4 +30,4 @@ def eval_string(input_string, locals):
 
     """
     # empty globals arg will append __builtins__ by default
-    return eval(input_string, {}, locals)
+    return eval(input_string, globals, locals)

--- a/tests/arbpack/arbmod2.py
+++ b/tests/arbpack/arbmod2.py
@@ -1,0 +1,6 @@
+"""Arbitrary module with a test attribute."""
+
+
+def arb_func_in_arbmod2(arg):
+    """Arbitrary function just returns input."""
+    return arg

--- a/tests/arbpack/arbmod3.py
+++ b/tests/arbpack/arbmod3.py
@@ -1,0 +1,6 @@
+"""Arbitrary module with a test attribute."""
+
+
+def arb_func_in_arbmod3(arg):
+    """Arbitrary function just returns input."""
+    return arg

--- a/tests/arbpack/arbmod4_avoid.py
+++ b/tests/arbpack/arbmod4_avoid.py
@@ -1,0 +1,15 @@
+"""Arbitrary module with a test attribute.
+
+DON'T use me anywhere except moduleloader_test.py > test_import_visitor.
+
+Because otherwise coverage will drop <100% since Python import machinery will
+cache the module lookup and test_import_visitor explicitly tests a code-path
+where a module is not found in cache.
+
+Believe it or not, this is the least painful way of achieving it.
+"""
+
+
+def arb_func_in_arbmod4(arg):
+    """Arbitrary function just returns input."""
+    return arg

--- a/tests/arbpack/arbmultiattr.py
+++ b/tests/arbpack/arbmultiattr.py
@@ -1,0 +1,8 @@
+"""Arbitrary module with multiple attributes."""
+
+arb_attr = 123.456
+
+
+def arb_func(arg):
+    """Arbitrary function just returns input."""
+    return arg

--- a/tests/integration/pypyr/pype/pype_int_test.py
+++ b/tests/integration/pypyr/pype/pype_int_test.py
@@ -19,3 +19,12 @@ def test_pype_err_int():
     test_pipe_runner.assert_pipeline_notify_output_is(pipename, ['A',
                                                                  'B',
                                                                  'C'])
+
+
+def test_pype_pyimport():
+    """Pype while passing pyimports to child."""
+    pipename = 'pype/pyimport/parent'
+    test_pipe_runner.assert_pipeline_notify_output_is(pipename, ['A',
+                                                                 'B',
+                                                                 'C',
+                                                                 'D'])

--- a/tests/pipelines/pype/pyimport/child-new-context.yaml
+++ b/tests/pipelines/pype/pyimport/child-new-context.yaml
@@ -1,0 +1,27 @@
+steps:
+  # can't use parent import in child, new context
+  - name: pypyr.steps.assert
+    swallow: True
+    in:
+      assert:
+        this: !py abs(a) + math.sqrt(b)
+        equals: 5
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{runErrors[0][description]}'
+        equals: name 'math' is not defined
+  
+  # child only import
+  - name: pypyr.steps.pyimport
+    in:
+      pyImport: from tests.arbpack.arbmod2 import arb_func_in_arbmod2
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: !py arb_func_in_arbmod2('hello there')
+        equals: hello there
+
+  - name: pypyr.steps.echo
+    in:
+      echoMe: B

--- a/tests/pipelines/pype/pyimport/child-parent-context.yaml
+++ b/tests/pipelines/pype/pyimport/child-parent-context.yaml
@@ -1,0 +1,24 @@
+steps:
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: !py abs(a) + math.sqrt(b)
+        equals: 5
+
+  # child import will work in parent too because shared context
+  - name: pypyr.steps.pyimport
+    in:
+      pyImport: |
+        from tests.arbpack.arbmod2 import arb_func_in_arbmod2
+        import tests.arbpack.arbmod3
+
+  - name: pypyr.steps.assert
+    swallow: True
+    in:
+      assert:
+        this: !py arb_func_in_arbmod2('will work') + tests.arbpack.arbmod3.arb_func_in_arbmod3(' too')
+        equals: will work too
+
+  - name: pypyr.steps.echo
+    in:
+      echoMe: C

--- a/tests/pipelines/pype/pyimport/parent.yaml
+++ b/tests/pipelines/pype/pyimport/parent.yaml
@@ -1,0 +1,54 @@
+steps:
+  - name: pypyr.steps.echo
+    in:
+      echoMe: A
+  - name: pypyr.steps.pyimport
+    in:
+      pyImport: import math
+  - name: pypyr.steps.pype
+    in:
+      pype:
+        name: pype/pyimport/child-new-context
+        args:
+          a: -3
+          b: 4
+
+  # child only import doesn't apply to parent
+  - name: pypyr.steps.assert
+    swallow: True
+    in:
+      assert: !py arb_func_in_arbmod2('should fail')
+  - name: pypyr.steps.assert
+    in:
+      assert:
+        this: '{runErrors[0][description]}'
+        equals: name 'arb_func_in_arbmod2' is not defined
+
+  # parent imports apply to child
+  - name: pypyr.steps.pype
+    in:
+      a: -3
+      b: 4
+      pype:
+        name: pype/pyimport/child-parent-context
+
+  # can use child imports in parent because shared context
+  - name: pypyr.steps.pyimport
+    comment: repeat import to same parent works
+    in:
+      pyImport: import tests.arbpack.arbmultiattr
+
+  - name: pypyr.steps.assert
+    swallow: True
+    in:
+      arb_int: 6.1
+      assert:
+        this: !py arb_func_in_arbmod2('will work 2') +
+          tests.arbpack.arbmod3.arb_func_in_arbmod3(' too 2') +
+          tests.arbpack.arbmultiattr.get_func(' end ') + 
+          str(math.floor(arb_int))
+        equals: will work too 2 end 6
+
+  - name: pypyr.steps.echo
+    in:
+      echoMe: D

--- a/tests/unit/pypyr/cache/namespacecache_test.py
+++ b/tests/unit/pypyr/cache/namespacecache_test.py
@@ -1,0 +1,63 @@
+"""namespacecache.py unit tests."""
+from sys import intern
+from unittest.mock import patch
+
+import pypyr.cache.namespacecache as namespacecache
+from pypyr.moduleloader import ImportVisitor
+
+# region parse_and_load
+
+
+def test_get_namespace_parse_and_load():
+    """Parse and load returns namespace dict."""
+    source = """\
+import math
+import tests.arbpack.arbmod
+from tests.arbpack import arbmod2
+from tests.arbpack import arbmod3 as ab3
+from tests.arbpack.arbmultiattr import arb_attr as x, arb_func as y
+"""
+    out = namespacecache.NamespaceCache().get_namespace(source)
+
+    assert len(out) == 6
+    assert all(key in out for key in ['math', 'tests', 'arbmod2', 'ab3',
+                                      'x', 'y'])
+
+
+# endregion parse_and_load
+
+# region NamespaceCache
+
+# region NamespaceCache: get_namespace
+
+
+def test_get_namespace_cache_hit():
+    """Get namespace interns and hits cache."""
+    with patch.object(ImportVisitor,
+                      'get_namespace',
+                      return_value='ns') as mock:
+        ns = namespacecache.NamespaceCache().get_namespace("arbkey")
+
+    mock.assert_called_once_with('arbkey')
+    assert ns == "ns"
+
+
+def test_get_namespace_same_obj():
+    """Get namespace returns same obj for same source."""
+    source = "from tests.arbpack import arbmod3 as ab3"
+    cache = namespacecache.NamespaceCache()
+    ns = cache.get_namespace(source)
+    assert len(ns) == 1
+    assert ns['ab3'].arb_func_in_arbmod3(321) == 321
+
+    ns2 = cache.get_namespace("from tests.arbpack import arbmod3 as ab3")
+    assert ns2 is ns
+    assert len(ns) == 1
+    assert ns['ab3'].arb_func_in_arbmod3(321) == 321
+
+    intern("from tests.arbpack import arbmod3 as ab3") is list(
+        cache._cache.keys())[0]
+
+# endregion NamespaceCache: get_namespace
+
+# endregion NamespaceCache

--- a/tests/unit/pypyr/dsl_test.py
+++ b/tests/unit/pypyr/dsl_test.py
@@ -363,7 +363,7 @@ def test_py_string_behaves():
     py = PyString('1+1')
     assert str(py) == '1+1'
     assert repr(py) == "PyString('1+1')"
-    assert py.get_value({}) == 2
+    assert py.get_value(Context()) == 2
 
 
 def test_py_string_class_methods():
@@ -375,7 +375,7 @@ def test_py_string_class_methods():
     assert isinstance(new_instance, PyString)
     assert str(new_instance) == 'False and False'
     assert repr(new_instance) == "PyString('False and False')"
-    assert not new_instance.get_value({})
+    assert not new_instance.get_value(Context())
 
     mock_representer = MagicMock()
     PyString.to_yaml(mock_representer, mock_node)
@@ -387,6 +387,14 @@ def test_py_string_class_methods():
 def test_py_string_with_context():
     """Py string works with Context."""
     assert PyString('len(a)').get_value(Context({'a': '123'})) == 3
+
+
+def test_py_string_with_imports():
+    """Py string can use imported global namespace."""
+    context = Context({'a': -3, 'b': 4})
+    from math import sqrt
+    context.pystring_globals.update({'squareroot': sqrt})
+    assert PyString('abs(a) + squareroot(b)').get_value(context) == 5
 
 
 def test_py_string_eq_and_neq():
@@ -402,7 +410,7 @@ def test_py_string_repr_roundtrip():
     assert repr_string == 'PyString(\'len("three")\')'
     reconstituted = eval(repr_string)
     assert isinstance(reconstituted, PyString)
-    assert reconstituted.get_value({}) == 5
+    assert reconstituted.get_value(Context()) == 5
 
 
 def test_py_string_empty():
@@ -414,7 +422,7 @@ def test_py_string_empty():
                               'valid python expression instead.')
 
     with pytest.raises(ValueError) as err:
-        PyString('').get_value({})
+        PyString('').get_value(Context())
 
 
 def test_py_string_truthy():

--- a/tests/unit/pypyr/steps/contextclearall_test.py
+++ b/tests/unit/pypyr/steps/contextclearall_test.py
@@ -17,13 +17,17 @@ def test_context_clear_all_pass():
         ]
     })
 
+    context.pystring_globals.update({'a': 'b'})
+
     pypyr.steps.contextclearall.run_step(context)
 
     assert len(context) == 0
-
     assert context is not None
-
     assert isinstance(context, Context)
+
+    assert len(context.pystring_globals) == 0
+    assert context.pystring_globals is not None
+    assert type(context.pystring_globals) is dict
 
     context['k1'] = 'value1'
 
@@ -37,3 +41,4 @@ def test_context_clear_all_context_empty_already():
     pypyr.steps.contextclearall.run_step(context)
 
     assert len(context) == 0
+    assert len(context.pystring_globals) == 0

--- a/tests/unit/pypyr/steps/pyimport_test.py
+++ b/tests/unit/pypyr/steps/pyimport_test.py
@@ -1,0 +1,104 @@
+"""pyimport.py unit tests."""
+from pathlib import Path
+from pypyr.context import Context
+from pypyr.dsl import PyString
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
+import pypyr.steps.pyimport as pyimport
+import pytest
+
+
+def test_pyimport_none():
+    """No pyimport input raises."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        context = Context({'blah': 'blah blah'})
+        pyimport.run_step(context)
+
+    assert str(err_info.value) == ("context['pyImport'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.pyimport.")
+
+
+def test_pyimport_key_exists_but_none():
+    """None source string raises."""
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        context = Context({'pyImport': None})
+        pyimport.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['pyImport'] must have a value for pypyr.steps.pyimport.")
+
+
+def test_pyimport_empty():
+    """Empty source string imports nothing."""
+    context = Context({'pyImport': ''})
+    pyimport.run_step(context)
+    len(context.pystring_globals) == 0
+
+
+def test_pyimport():
+    """Import namespace saved to context."""
+    source = """\
+import math
+
+import tests.arbpack.arbmod
+import tests.arbpack.arbmod2
+
+from tests.arbpack.arbmultiattr import arb_attr, arb_func as y
+"""
+    context = Context({'pyImport': source})
+    pyimport.run_step(context)
+    ns = context.pystring_globals
+    len(ns) == 4
+
+    assert ns['math'].sqrt(4) == 2
+    # no return value but shouldn't raise not found.
+    ns['tests'].arbpack.arbmod.arbmod_attribute()
+    assert ns['arb_attr'] == 123.456
+    assert ns['y']('ab3') == 'ab3'
+
+    # parent did not import anything NOT specified.
+    # tests.arbpack.arbstep exists but wasn't specified for import.
+    assert not hasattr(ns['tests'].arbpack, 'arbstep')
+    # python has a quirk where if a submodule was imported anywhere else, it's
+    # imported & cached for the global namespace of the parent package. So
+    # arbmod3, which is used elsewhere in unit tests, might well be an
+    # attribute of arbpack here even though not explicitly specified, if part
+    # of the test-run included any code somewhere doing
+    # import tests.arbpack.arbmod3.
+    #
+    # importlib.invalidate_caches() doesn't help
+    # assert not hasattr(ns['tests'].arbpack, 'arbmod3') --> will FAIL
+
+
+def test_pyimport_update_not_replace():
+    """Import updates/merges to namespace dict, not overwrite."""
+    context = Context({'pyImport': 'import math; import tests.arbpack.arbmod'})
+    pyimport.run_step(context)
+
+    context['pyImport'] = """\
+from pathlib import Path
+import tests.arbpack.arbmod3
+"""
+
+    # 2nd run should merge into ns dict, not overwrite.
+    pyimport.run_step(context)
+    ns = context.pystring_globals
+    len(ns) == 3
+
+    assert ns['math'].sqrt(4) == 2
+    # both the arbpack imports valid because of python submodule global imports
+    ns['tests'].arbpack.arbmod.arbmod_attribute()
+    assert ns['tests'].arbpack.arbmod3.arb_func_in_arbmod3('ab3') == 'ab3'
+    assert ns['Path'].cwd() == Path.cwd()
+
+
+def test_pyimport_with_pystring():
+    """Pystring evals with the globals namespace from pyimport."""
+    context = Context({'a': -1,
+                       'b': 'xx',
+                       'c': 4,
+                       'pyImport': 'import math',
+                       'out': PyString('abs(a) + len(b) + math.sqrt(c)')})
+    pyimport.run_step(context)
+
+    assert context.get_formatted('out') == 5

--- a/tests/unit/pypyr/utils/expressions_test.py
+++ b/tests/unit/pypyr/utils/expressions_test.py
@@ -1,36 +1,36 @@
 """expressions.py unit tests."""
-
-from math import sqrt
+from math import ceil, sqrt
 import pytest
 from pypyr.context import Context
 import pypyr.utils.expressions as expressions
 
 
 def test_simple_expr_none_dict():
-    """Simple expression passes, with no locals dict."""
-    assert expressions.eval_string('1+1', None) == 2
+    """Simple expression passes, with no locals+globals dict."""
+    assert expressions.eval_string('1+1', None, None) == 2
 
 
 def test_simple_expr_empty_dict():
-    """Simple expression passes, with no locals dict."""
-    out = expressions.eval_string('len("123456") < 5', {})
+    """Simple expression passes, with empty locals+globals dict."""
+    out = expressions.eval_string('len("123456") < 5', {}, {})
     assert isinstance(out, bool)
     assert not out
 
 
 def test_simple_expr_locals_dict():
     """Simple expression passes, with locals dict."""
-    assert expressions.eval_string('sqrt(4)', {'sqrt': sqrt}) == 2
+    assert expressions.eval_string('sqrt(4)', {}, {'sqrt': sqrt}) == 2
 
 
 def test_expr_dict_vars():
     """Expression uses vars from input dict."""
-    assert expressions.eval_string('(k1 + k2)*2==10', {'k1': 2, 'k2': 3})
+    assert expressions.eval_string('(k1 + k2)*2==10', {}, {'k1': 2, 'k2': 3})
 
 
 def test_expr_dict_nested_vars():
     """Expression uses nested vars from input dict."""
     assert expressions.eval_string('k2[2]["k2.2"] == 1.23',
+                                   {},
                                    {'k1': 1,
                                     'k2': [0,
                                            1,
@@ -42,34 +42,54 @@ def test_expr_dict_nested_vars():
 
 def test_expr_evals_bool():
     """Expression can work as a boolean type."""
-    out = expressions.eval_string("a", {'a': True})
+    out = expressions.eval_string("a", {}, {'a': True})
     assert isinstance(out, bool)
     assert out
 
 
 def test_expr_evals_complex():
     """Expression evaluates complex types."""
-    assert expressions.eval_string('{"a": "b"} == c', {'c': {'a': 'b'}})
+    assert expressions.eval_string('{"a": "b"} == c', {}, {'c': {'a': 'b'}})
 
 
 def test_expr_runtime_error():
     """Expression raises expected type during runtime error."""
     with pytest.raises(ZeroDivisionError):
-        expressions.eval_string('1/0', None)
+        expressions.eval_string('1/0', None, None)
 
 
 def test_expr_invalid_syntax():
-    """Expression raises when invalid sytntax on input."""
+    """Expression raises when invalid syntax on input."""
     with pytest.raises(SyntaxError):
-        expressions.eval_string('invalid code here', None)
+        expressions.eval_string('invalid code here', None, None)
 
 
 def test_expr_var_doesnt_exist():
     """Expression raises when variable not found in namespace."""
     with pytest.raises(NameError):
-        expressions.eval_string('a', {'b': True})
+        expressions.eval_string('a', None, {'b': True})
 
 
 def test_expr_func_when_context_as_locals():
     """Expression should use built-in function when Context used as locals."""
-    assert expressions.eval_string('len([0,1,2])', Context({'k1': 'v1'})) == 3
+    assert expressions.eval_string('len([0,1,2])',
+                                   None,
+                                   Context({'k1': 'v1'})) == 3
+
+    assert expressions.eval_string('len([0,1,2])',
+                                   {},
+                                   Context({'k1': 'v1'})) == 3
+
+
+def test_expr_builtin_globals_and_locals():
+    """Expression evaluates with builtin, globals and locals."""
+    assert expressions.eval_string('a+b + ceil(b) + abs(-1)',
+                                   {'ceil': ceil},
+                                   Context({'a': 1, 'b': 2})) == 6
+
+
+def test_expr_only_globals():
+    """Expression evaluates with only globals."""
+    assert expressions.eval_string('abs(a+b)',
+                                   {'a': 11, 'b': 22},
+                                   {}) == 33

--- a/tests/unit/pypyr/yaml_test.py
+++ b/tests/unit/pypyr/yaml_test.py
@@ -6,7 +6,7 @@ from pypyr.context import Context
 import pypyr.yaml as pypyr_yaml
 
 
-# ----------------- get_pipeline_yaml ----------------------------------------
+# region get_pipeline_yaml
 def test_get_pipeline_yaml_simple():
     """Pipeline yaml loads with simple yaml."""
     file = io.StringIO('1: 2\n2: 3')
@@ -19,12 +19,13 @@ def test_get_pipeline_yaml_custom_types():
     """Pipeline yaml loads with custom types."""
     file = io.StringIO('1: !sic "{12}"\n2: !py abs(-23)\n3: !sic\n4: !py')
     pipeline = pypyr_yaml.get_pipeline_yaml(file)
+    context = Context()
 
     assert len(pipeline) == 4
     assert pipeline[1].get_value() == '{12}'
     assert repr(pipeline[2]) == "PyString('abs(-23)')"
     assert pipeline[2].value == 'abs(-23)'
-    assert pipeline[2].get_value({}) == 23
+    assert pipeline[2].get_value(context) == 23
     # empty sic
     assert repr(pipeline[3]) == "SicString('')"
     assert pipeline[3].get_value({}) == ''
@@ -32,14 +33,14 @@ def test_get_pipeline_yaml_custom_types():
     assert repr(pipeline[4]) == "PyString('')"
 
     with pytest.raises(ValueError) as err:
-        pipeline[4].get_value({})
+        pipeline[4].get_value(context)
         assert str(err.value) == (
             '!py string expression is empty. It must be a valid python '
             'expression instead.')
 
-# ----------------- END get_pipeline_yaml -------------------------------------
+# endregion get_pipeline_yaml
 
-# ----------------- get_yaml_parser -------------------------------------------
+# region get_yaml_parser
 
 
 def test_get_yaml_parser_safe():
@@ -69,4 +70,4 @@ def test_get_yaml_parser_roundtrip_context():
     assert obj.sequence_dash_offset == 2
     assert obj.Representer.yaml_representers[Context] == (
         yamler.representer.RoundTripRepresenter.represent_dict)
-# ----------------- END get_yaml_parser ---------------------------------------
+# endregion get_yaml_parser ---------------------------------------


### PR DESCRIPTION
- new step `pypyr.steps.pyimport` to import references to the py-string namespace.
    - This includes an underlying api signature change to `pypyr.utils.expressions.eval_string()`, but this is sufficiently far down the call-chain that it shouldn’t affect any normal pipeline operator or api consumer.
- `pypyr.steps.contextclearall` wipes pyimport imported references in addition to the key/values inside context.