### PR TITLE
release 4.4.0

### DIFF
--- a/ops/build.yaml
+++ b/ops/build.yaml
@@ -132,6 +132,8 @@ get_version:
 
         version = f'{version_module.__version__}'
         is_version_module_loaded = True
+
+        save('version', 'is_version_module_loaded')
   - name: pypyr.steps.echo
     in:
       echoMe: version is {version}

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.3.0'
+__version__ = '4.4.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.0
+current_version = 4.4.0
 
 [bumpversion:file:pypyr/version.py]
 


### PR DESCRIPTION
- fix ops/build to use new `py` style syntax for `pypyr.steps.py` 
- version bump for release


Release contains:
- New step `pypyr.steps.pyimport` to import references to the py-string namespace.
    - This includes an underlying api signature change by removal of `pypyr.utils.expressions.eval_string()`, but this is sufficiently far down the call-chain that it shouldn’t affect any normal pipeline operator or api consumer.
- `pypyr.steps.contextclearall` wipes `pyimport` imported references in addition to the key/values inside context.
- Simplify `pypyr.steps.py` syntax by allowing a new `py` (rather than `pycode`) input. This allows pipeline authors to use context key names directly as variables, rather than have to specify them as keys in context (`my_var` vs `context[‘my_var’]`).
    - see #204 for details on simplifying the `pypyr.steps.py` syntax.
    - this involves an unusual implementation of namespaces, fully documented in ./adr/docs/0001-namespace-on-eval-and-exec.md. See #205. 
    - the old `pycode` will keep on working in the same way, so no need to worry about backwards compatibility for your existing pipelines.
- Allow substitutions on Retry `max`. Resolves #207. Excellent bug find & fix by @Reskov, much thanks as ever for a superb contribution! 🔥 🔥 🔥 