### PR TITLE
context parsers initialize empty rather than None. closes #214.

### DIFF
--- a/pypyr/parser/dict.py
+++ b/pypyr/parser/dict.py
@@ -25,7 +25,7 @@ def get_parsed_context(args):
                      "dict parser you can use something "
                      "like:\n"
                      "pypyr pipelinename key1=value1 key2=value2")
-        return {'argDict': None}
+        return {'argDict': {}}
 
     # for each input argument, project key=value
     return {'argDict':

--- a/pypyr/parser/list.py
+++ b/pypyr/parser/list.py
@@ -21,7 +21,7 @@ def get_parsed_context(args):
                      "pypyr pipelinename spam eggs\n"
                      "OR: pypyr pipelinename spam."
                      )
-        return {'argList': None}
+        return {'argList': []}
 
     # the list that's parsed from the input args is named argList
     return dict({'argList': args})

--- a/pypyr/parser/string.py
+++ b/pypyr/parser/string.py
@@ -20,7 +20,7 @@ def get_parsed_context(args):
                      "this string parser you're looking for something "
                      "like: pypyr pipelinename spam and eggs"
                      )
-        return {'argString': None}
+        return {'argString': ''}
 
     # the list that's parsed from the input args is named argList
     return dict({'argString': ' '.join(args)})

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.4.0'
+__version__ = '4.4.1'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.0
+current_version = 4.4.1
 
 [bumpversion:file:pypyr/version.py]
 

--- a/tests/unit/pypyr/parser/dict_test.py
+++ b/tests/unit/pypyr/parser/dict_test.py
@@ -40,3 +40,4 @@ def test_empty_string_empty_dict_argdict():
 
     assert out
     assert not out['argDict']
+    assert out['argDict'] == {}

--- a/tests/unit/pypyr/parser/list_test.py
+++ b/tests/unit/pypyr/parser/list_test.py
@@ -28,7 +28,8 @@ def test_empty_args_empty_list():
             'pypyr.parser.list', logging.DEBUG) as mock_logger_debug:
         out = pypyr.parser.list.get_parsed_context(None)
 
-    assert out['argList'] is None
+    assert not out['argList']
+    assert out['argList'] == []
     mock_logger_debug.assert_called_with(
         "pipeline invoked without context arg set. For "
         "this list parser you're looking for something like:\n"

--- a/tests/unit/pypyr/parser/string_test.py
+++ b/tests/unit/pypyr/parser/string_test.py
@@ -35,7 +35,8 @@ def test_empty_string_warns():
             'pypyr.parser.string', logging.DEBUG) as mock_logger_debug:
         out = pypyr.parser.string.get_parsed_context(None)
 
-    assert out['argString'] is None
+    assert not out['argString']
+    assert out['argString'] == ''
     mock_logger_debug.assert_called_with(
         "pipeline invoked without context arg set. For "
         "this string parser you're looking for something "


### PR DESCRIPTION
- context parsers that create an entry in context currently initialise to `None`. this is annoying downstream because you constantly have to deal with the None exception case - e.g you can't just directly jump into a `for` loop. closes #214.
- version bump for release