### PR TITLE
retry backoff

### DIFF
--- a/pypyr/cache/backoffcache.py
+++ b/pypyr/cache/backoffcache.py
@@ -1,0 +1,85 @@
+"""Global cache for retry back-off callables.
+
+Attributes:
+    backoff_cache: Global instance of the retry back-off callable cache.
+                   Use this attribute to access the cache from elsewhere.
+"""
+import logging
+from pypyr.cache.cache import Cache
+import pypyr.moduleloader
+import pypyr.retries
+
+logger = logging.getLogger(__name__)
+
+
+class BackoffCache(Cache):
+    """Get retry strategy callable objects from the Backoff cache."""
+
+    def __init__(self):
+        """Initialize the cache with the built-in back-off strategies."""
+        super().__init__()
+        self._cache = pypyr.retries.builtin_backoffs.copy()
+
+    def clear(self):
+        """Clear the cache of all objects except built-in back-offs.."""
+        with self._lock:
+            # rather than iterating & selectively removing, just reset entirely
+            self._cache = pypyr.retries.builtin_backoffs.copy()
+
+    def get_backoff(self, name):
+        """Get cached backoff callable. Adds to cache if not exist.
+
+        Args:
+            name: load the package.module.class specified & add the object
+                reference to cache.
+
+        Return:
+            callable: the function/callable reference specified by name.
+        """
+        logger.debug("starting")
+
+        backoff = self.get(name, lambda: load_backoff_callable(name))
+
+        logger.debug("done")
+        return backoff
+
+
+# global instance of the cache. use this to access the cache from elsewhere.
+backoff_cache = BackoffCache()
+
+
+def load_backoff_callable(name):
+    """Load the backoff retry callable specified by name.
+
+    Args:
+        name: (string) Absolute name of callable to load.
+
+    Returns:
+        Reference to the callable specified by name.
+    """
+    logger.debug("starting")
+
+    module_name, dot, attr_name = name.rpartition('.')
+    if not dot:
+        # just a bare name, no dot, means must be in globals.
+        # note that built-in backoffs already in cache, so this will only run
+        # for bare names that aren't built-in back-offs.
+        raise ValueError(
+            f"Trying to find back-off strategy '{name}'. If this is a "
+            "built-in back-off strategy, are you sure you got the name right?"
+            "\nIf you're trying to load a custom callable, name should be in "
+            "format 'package.module.ClassName' or 'mod.ClassName'.")
+
+    backoff_module = pypyr.moduleloader.get_module(module_name)
+    logger.debug("retry backoff strategy module loaded: %s", backoff_module)
+
+    try:
+        backoff_callable = getattr(backoff_module, attr_name)
+    except AttributeError:
+        logger.error(("Looking for retry back-off strategy %s. "
+                      "The callable %s doesn't exist in module %s."),
+                     name, attr_name, backoff_module)
+        raise
+    logger.debug("done")
+
+    return backoff_callable

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -929,19 +929,16 @@ class RetryDecorator:
                 "retry decorator will try indefinitely with %s backoff "
                 "starting at %ss intervals.", backoff_name, sleep)
 
-        # this will never be false. because on counter == max,
-        # exec_iteration raises an exception, breaking out of the loop.
-        # pragma because cov doesn't know the implied else is impossible.
-        # unit test cov is 100%, though.
-        if poll.while_until_true(interval=backoff_callable,
-                                 max_attempts=max)(
-                self.exec_iteration)(context=context,
-                                     step_method=step_method,
-                                     max=max
-                                     ):  # pragma: no cover
-            logger.debug("retry loop complete, reporting success.")
-
-        logger.debug("retry loop done")
+        # this will never be false. because on (counter == max) exec_iteration
+        # raises an exception, breaking out of the loop.
+        is_retry_ok = poll.while_until_true(interval=backoff_callable,
+                                            max_attempts=max)(
+            self.exec_iteration)(context=context,
+                                 step_method=step_method,
+                                 max=max
+                                 )
+        assert is_retry_ok
+        logger.debug("retry loop complete, reporting success.")
 
         logger.debug("done")
 

--- a/pypyr/retries.py
+++ b/pypyr/retries.py
@@ -1,0 +1,152 @@
+"""pypyr retry back-off strategies.
+
+If you add a back-off strategy, be sure to add it also to the builtin_backoffs
+attribute at the bottom.
+
+Attributes:
+    builtin_backoffs: dict mapping back-off name to implementation class.
+"""
+import abc
+from collections import deque
+import random
+
+
+# region backoff base
+class BackoffBase(abc.ABC):
+    """Derive from me for a custom back-off strategy.
+
+    Attributes:
+        sleep (float): initial sleep interval in seconds.
+        max_sleep (float): upper bound for sleep interval calculation.
+        jrc (float): Jitter Range Coefficient.
+        kwargs (dict): arbitrary keyword args for use in deriving classes.
+    """
+
+    def __init__(self, sleep=1, max_sleep=None, jrc=0, kwargs=None):
+        """Initialize back-off strategy.
+
+        Args:
+            sleep (float): positive sleep interval in seconds.
+            max_sleep (float): upper bound for sleep interval calculation.
+            jrc (float): jitter randomizes between [sleep*jrc] and [sleep].
+            kwargs (dict): arbitrary arguments for use by deriving classes.
+        """
+        self.sleep = sleep
+        self.max_sleep = max_sleep
+        self.jrc = jrc
+        self.kwargs = kwargs
+
+    @abc.abstractmethod
+    def __call__(self, n):
+        """Implement back-off sleep interval calculation here.
+
+        Args:
+            n (int): The iteration counter.
+
+        Returns:
+            Float. The sleep interval for iteration n.
+        """
+        raise NotImplementedError()  # pragma: no cover
+
+    def min(self, sleep):
+        """Return the smaller of sleep vs max_sleep."""
+        max_sleep = self.max_sleep
+        return min(sleep, max_sleep) if max_sleep else sleep
+
+    def randomize(self, sleep):
+        """Get random number in between (jrc*sleep) and (sleep).
+
+        Does NOT guard against result < max_sleep. This is on purpose.
+        It allows you to jitter under or over the sleep interval depending on
+        if jrc > 1.
+        """
+        return random.uniform(sleep*self.jrc, sleep)
+
+# endregion backoff base
+
+# region backoff strategies implementation
+
+
+class fixed(BackoffBase):
+    """Fixed backoff interval(s).
+
+    Sleep can be a single fixed interval, or a list with sleep intervals.
+
+    In the case of a list, each retry iteration will use the next value in the
+    list as the back-off interval, until it reaches the last item, which will
+    repeat indefinitely.
+    """
+
+    def __init__(self, sleep, max_sleep=None, jrc=0, kwargs=None):
+        """Initialize the fixed back-off strategy."""
+        super().__init__(sleep, max_sleep, jrc, kwargs)
+        if isinstance(sleep, (list, set)):
+            self.queue = deque(sleep, len(sleep))
+            self.fixed_sleep = self.min(self.queue[-1])
+        else:
+            self.queue = None
+            self.fixed_sleep = self.min(sleep)
+
+    def __call__(self, n):
+        """Return the fixed backoff interval or the next item on list."""
+        if self.queue:
+            return self.min(self.queue.popleft())
+
+        return self.fixed_sleep
+
+
+class jitter(fixed):
+    """Add jitter over fixed."""
+
+    def __call__(self, n):
+        """Randomize the fixed backoff interval."""
+        return self.randomize(super().__call__(n))
+
+
+class linear(BackoffBase):
+    """Backoff increases linearly - the product of iteration and sleep."""
+
+    def __call__(self, n):
+        """Return the product of n * sleep."""
+        return self.min(n*self.sleep)
+
+
+class linearjitter(linear):
+    """Add jitter over linear."""
+
+    def __call__(self, n):
+        """Randomize the product of n * sleep."""
+        return self.randomize(super().__call__(n))
+
+
+class exponential(BackoffBase):
+    """Backoff with exponential growth of the sleep coefficient."""
+
+    def __init__(self, sleep=1, max_sleep=None, jrc=0, kwargs=None):
+        """Initialize the fixed back-off strategy."""
+        super().__init__(sleep, max_sleep, jrc, kwargs)
+        self.base = kwargs.get('base', 2) if kwargs else 2
+
+    def __call__(self, n):
+        """Return (base**n)*sleep."""
+        return self.min(pow(self.base, n) * self.sleep)
+
+
+class exponentialjitter(exponential):
+    """Add jitter over exponential."""
+
+    def __call__(self, n):
+        """Randomize exponential result of n."""
+        return self.randomize(super().__call__(n))
+
+# endregion backoff strategies implementation
+
+
+builtin_backoffs = {
+    'fixed': fixed,
+    'jitter': jitter,
+    'linear': linear,
+    'linearjitter': linearjitter,
+    'exponential': exponential,
+    'exponentialjitter': exponentialjitter
+}

--- a/pypyr/utils/poll.py
+++ b/pypyr/utils/poll.py
@@ -99,10 +99,8 @@ def while_until_true(interval, max_attempts):
                 else:
                     logger.debug("Looping every %s seconds.", interval)
 
-            # pragma for coverage: cov can't figure out the branch construct
-            # with the dynamic function invocation, it seems, so marks the
-            # branch partial. unit test cov is 100%, though.
-            while not result:  # pragma: no branch
+            # loop breaks explicitly for all possible exit conditions
+            while True:
                 i += 1
                 result = f(i, *args, **kwargs)
 

--- a/tests/arbpack/arbcallables.py
+++ b/tests/arbpack/arbcallables.py
@@ -1,0 +1,13 @@
+"""Arbitrary callables for testing."""
+
+
+class ArbCallable():
+    """Arb callable test class."""
+
+    def __init__(self, ctorarg):
+        """Arbitrary ctor."""
+        self.ctorarg = ctorarg
+
+    def __call__(self, arg1):
+        """Make it callable."""
+        return f'from callable: {self.ctorarg} {arg1}'

--- a/tests/integration/pypyr/retries/retry_int_test.py
+++ b/tests/integration/pypyr/retries/retry_int_test.py
@@ -1,0 +1,32 @@
+"""retry integration tests."""
+from pathlib import Path
+from unittest.mock import call, patch
+from pypyr import pipelinerunner
+
+working_dir_tests = Path(Path.cwd(), 'tests')
+
+
+@patch('pypyr.retries.random.uniform', return_value=123)
+@patch('time.sleep')
+def test_retry_with_yaml_anchor(mock_sleep, mock_random):
+    """Retry uses common shared anchors."""
+    out = pipelinerunner.main_with_context(
+        pipeline_name='pipelines/retries/retry-anchors',
+        dict_in={'outList': []},
+        working_dir=working_dir_tests)
+
+    assert out['outList'] == ['s1.1',
+                              's1.2',
+                              's1.3',
+                              's2.1',
+                              's2.2',
+                              's3.1',
+                              's3.2',
+                              's3.3']
+
+    assert mock_random.mock_calls == [call(1.5, 3), call(4.25, 8.5)]
+    assert mock_sleep.mock_calls == [call(2),
+                                     call(4),
+                                     call(2),
+                                     call(123),
+                                     call(123)]

--- a/tests/pipelines/retries/retry-anchors.yaml
+++ b/tests/pipelines/retries/retry-anchors.yaml
@@ -1,0 +1,50 @@
+common:
+  retry1: &commonRetryFixedList
+    sleep: [2, 4, 8]
+    max: 3
+    sleepMax: 6
+
+  retry2: &commonRetryWithSubstitutions
+    sleep: '{base3_exponential_retry[sleep]}'
+    max: '{base3_exponential_retry[max]}'
+    sleepMax: '{base3_exponential_retry[sleepMax]}'
+    jrc: '{base3_exponential_retry[jrc]}'
+    backoff: '{base3_exponential_retry[backoff]}'
+    backoffArgs:
+      base: '{base3_exponential_retry[base]}'
+
+steps:
+  - name: pypyr.steps.py
+    retry: *commonRetryFixedList
+    in:
+      py: |
+        outList.append(f's1.{retryCounter}')
+        if retryCounter < 3:
+          raise ValueError('arb')
+
+  - name: pypyr.steps.py
+    retry: *commonRetryFixedList
+    in:
+      py: |
+        outList.append(f's2.{retryCounter}')
+        if retryCounter < 2:
+          raise ValueError('arb')
+
+  - name: pypyr.steps.contextsetf
+    in:
+      contextSetf:
+        base3_exponential_retry:
+          sleep: 1
+          max: 3
+          sleepMax: 8.5
+          jrc: 0.5
+          backoff: exponentialjitter
+          base: 3
+
+  - name: pypyr.steps.py
+    retry: *commonRetryWithSubstitutions
+    in:
+      py: |
+        outList.append(f's3.{retryCounter}')
+        if retryCounter < 3:
+          raise ValueError('arb')

--- a/tests/unit/pypyr/cache/backoffcache_test.py
+++ b/tests/unit/pypyr/cache/backoffcache_test.py
@@ -1,0 +1,117 @@
+"""backoffcache.py unit tests."""
+import pytest
+from unittest.mock import patch
+from pypyr.errors import PyModuleNotFoundError
+import pypyr.cache.backoffcache as backoffcache
+import pypyr.retries
+
+# region load_backoff_callable
+
+
+def test_load_backoff_callable_module_not_found():
+    """Module not found raises."""
+    with pytest.raises(PyModuleNotFoundError):
+        backoffcache.load_backoff_callable('blah-blah-xyz-argh.unlikely-name')
+
+
+def test_load_backoff_callable_attr_not_found():
+    """Attribute not found raises."""
+    with pytest.raises(AttributeError) as err:
+        backoffcache.load_backoff_callable(
+            'tests.arbpack.arbcallables.IDontExist')
+
+    assert str(err.value) == (
+        "module 'tests.arbpack.arbcallables' has no attribute 'IDontExist'")
+
+
+def test_load_backoff_callable_absolute():
+    """Load backoff callable with absolute name: package.module.class."""
+    f = backoffcache.load_backoff_callable(
+        'tests.arbpack.arbcallables.ArbCallable')
+
+    callable_ref = f('ctor in')
+    assert callable_ref('arg in 1') == 'from callable: ctor in arg in 1'
+    assert callable_ref('arg in 2') == 'from callable: ctor in arg in 2'
+
+
+def test_load_backoff_callable_bare():
+    """Load backoff callable with bare name (no dot)."""
+    with pytest.raises(ValueError) as err:
+        backoffcache.load_backoff_callable('local_test_arb_callable')
+
+    assert str(err.value) == (
+        "Trying to find back-off strategy 'local_test_arb_callable'. If this "
+        "is a built-in back-off strategy, are you sure you got the name right?"
+        "\nIf you're trying to load a custom callable, name should be in "
+        "format 'package.module.ClassName' or 'mod.ClassName'.")
+
+# endregion load_backoff_callable
+
+# region BackoffCache
+
+# region BackoffCache: get_backoff
+
+
+def test_get_backoff():
+    """Backoff callable loads ok."""
+    with patch('pypyr.cache.backoffcache.load_backoff_callable') as mock:
+        mock.return_value = lambda x: f"{x}test"
+        f = backoffcache.BackoffCache().get_backoff("arb")
+
+    mock.assert_called_once_with('arb')
+    assert f("arb") == "arbtest"
+
+    # it made a copy
+    assert 'arb' not in pypyr.retries.builtin_backoffs
+
+
+def test_get_backoff_builtin():
+    """Load built-in backoff callable."""
+    f = backoffcache.BackoffCache().get_backoff('fixed')
+
+    callable_ref = f(sleep=123, max_sleep=456)
+    assert callable_ref(789) == 123
+    assert callable_ref(999) == 123
+
+# endregion BackoffCache: get_backoff
+
+# region BackoffCache: clear
+
+
+def test_clear_doesnt_wipe_builtins():
+    """Clear shouldn't touch builtins."""
+    # Also doesn't touch the og look-up dict.
+    bc = backoffcache.BackoffCache()
+
+    og_len = len(bc._cache)
+    assert og_len > 1
+    assert 'fixed' in bc._cache
+
+    _ = bc.get_backoff('tests.arbpack.arbcallables.ArbCallable')
+    assert len(bc._cache) == og_len + 1
+
+    bc.clear()
+
+    # didn't touch the class's built-in dict
+    assert len(bc._cache) == og_len
+    assert 'fixed' in bc._cache
+
+    # twice in a row to verify clear also makes a copy
+    _ = bc.get_backoff('tests.arbpack.arbcallables.ArbCallable')
+    assert len(bc._cache) == og_len + 1
+    assert len(pypyr.retries.builtin_backoffs) == og_len
+
+    bc.clear()
+
+    # didn't touch the class's built-in dict
+    assert len(bc._cache) == og_len
+    assert 'fixed' in bc._cache
+
+    # didn't touch the shared built-in dict constant
+    assert len(pypyr.retries.builtin_backoffs) == og_len
+    assert 'fixed' in pypyr.retries.builtin_backoffs
+
+
+# endregion BackoffCache: clear
+
+# endregion BackoffCache

--- a/tests/unit/pypyr/retries_test.py
+++ b/tests/unit/pypyr/retries_test.py
@@ -1,0 +1,499 @@
+"""retries.py unit tests."""
+import inspect
+from unittest.mock import call, patch
+import pypyr.retries
+
+# region BackoffBase
+
+
+class ArbTestBackoff(pypyr.retries.BackoffBase):
+    """Test backoff derivation."""
+
+    def __call__(self, n):
+        """Just return n."""
+        return n
+
+
+def test_backoffbase_ctor_defaults():
+    """Backoff Base instantiates with defaults."""
+    b = ArbTestBackoff()
+    assert b.sleep == 1
+    assert b.max_sleep is None
+    assert b.jrc == 0
+    assert b.kwargs is None
+    assert b(123) == 123
+
+
+def test_backoffbase_ctor_all():
+    """Backoff Base instantiates with all values."""
+    b = ArbTestBackoff(sleep=123, max_sleep=456, jrc=789, kwargs={'a': 'b'})
+    assert b.sleep == 123
+    assert b.max_sleep == 456
+    assert b.jrc == 789
+    assert b.kwargs == {'a': 'b'}
+    assert b(123) == 123
+
+
+def test_backoffbase_min_none():
+    """Min when max_sleep None."""
+    b = ArbTestBackoff()
+    assert b.min(1) == 1
+    assert b.min(4) == 4
+
+
+def test_backoffbase_min():
+    """Min with value for max_sleep."""
+    b = ArbTestBackoff(max_sleep=3)
+    assert b.min(1) == 1
+    assert b.min(4) == 3
+
+
+@patch('pypyr.retries.random.uniform', return_value=123)
+def test_backoffbase_randomize(mock_random):
+    """Randomize uses product of jrc and sleep as one side bound for random."""
+    b = ArbTestBackoff(jrc=0.5)
+    assert b.randomize(3) == 123
+
+    mock_random.assert_called_once_with(1.5, 3)
+
+
+@patch('pypyr.retries.random.uniform', return_value=123)
+def test_backoffbase_randomize_jrc_gt_1(mock_random):
+    """Randomize can use jrc > 1."""
+    b = ArbTestBackoff(jrc=2)
+    assert b.randomize(3) == 123
+
+    mock_random.assert_called_once_with(6, 3)
+
+
+@patch('pypyr.retries.random.uniform', return_value=123)
+def test_backoffbase_randomize_default_0(mock_random):
+    """Randomize uses 0 as lower bound by default."""
+    b = ArbTestBackoff()
+    assert b.randomize(3) == 123
+
+    mock_random.assert_called_once_with(0, 3)
+
+# endregion BackoffBase
+
+# region retry strategies
+# region fixed
+
+
+def test_retries_fixed_with_single():
+    """Fixed with single float input."""
+    f = pypyr.retries.fixed(sleep=123)
+    assert f(0) == 123
+    assert f(1) == 123
+    assert f(2) == 123
+
+
+def test_retries_fixed_with_list():
+    """Fixed with list input."""
+    f = pypyr.retries.fixed(sleep=[2, 4, 6])
+    assert f(0) == 2
+    assert f(1) == 4
+    assert f(2) == 6
+    assert f(3) == 6
+    assert f(4) == 6
+    # arb repeat of n
+    assert f(0) == 6
+
+
+def test_retries_fixed_with_set():
+    """Fixed with list input."""
+    f = pypyr.retries.fixed(sleep={2, 4, 6})
+    assert f(0) == 2
+    assert f(1) == 4
+    assert f(2) == 6
+    assert f(3) == 6
+    assert f(4) == 6
+    # arb repeat of n
+    assert f(0) == 6
+
+
+def test_retries_fixed_single_with_max():
+    """Fixed with single float input works with max."""
+    f = pypyr.retries.fixed(sleep=123, max_sleep=456)
+    assert f(0) == 123
+    assert f(1) == 123
+    assert f(2) == 123
+
+    f = pypyr.retries.fixed(sleep=456, max_sleep=321)
+    assert f(0) == 321
+    assert f(1) == 321
+    assert f(2) == 321
+
+
+def test_retries_fixed_with_list_max():
+    """Fixed with list input works with max."""
+    f = pypyr.retries.fixed(sleep=[2, 4, 6], max_sleep=4.5)
+    assert f(0) == 2
+    assert f(1) == 4
+    assert f(2) == 4.5
+    assert f(3) == 4.5
+    assert f(4) == 4.5
+    # arb repeat of n
+    assert f(0) == 4.5
+
+# endregion fixed
+
+# region jitter
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_single(mock_random):
+    """Jitter with single float input."""
+    j = pypyr.retries.jitter(sleep=123)
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+
+    assert mock_random.mock_calls == [call(0, 123),
+                                      call(0, 123),
+                                      call(0, 123)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_single_max(mock_random):
+    """Jitter with single float input honors max."""
+    j = pypyr.retries.jitter(sleep=123, max_sleep=111)
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+
+    assert mock_random.mock_calls == [call(0, 111),
+                                      call(0, 111),
+                                      call(0, 111)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_list(mock_random):
+    """Jitter with list of float input."""
+    j = pypyr.retries.jitter(sleep=[1, 2, 3])
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+    assert j(3) == 999
+    assert j(4) == 999
+    # arb repeat
+    assert j(1) == 999
+
+    assert mock_random.mock_calls == [call(0, 1),
+                                      call(0, 2),
+                                      call(0, 3),
+                                      call(0, 3),
+                                      call(0, 3),
+                                      call(0, 3)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_list_max(mock_random):
+    """Jitter with list of float input honors max."""
+    j = pypyr.retries.jitter(sleep=[1, 2, 3], max_sleep=2)
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+    assert j(3) == 999
+    assert j(4) == 999
+    # arb repeat
+    assert j(1) == 999
+
+    assert mock_random.mock_calls == [call(0, 1),
+                                      call(0, 2),
+                                      call(0, 2),
+                                      call(0, 2),
+                                      call(0, 2),
+                                      call(0, 2)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_single_jrc_down(mock_random):
+    """Jitter with single float input and jrc < 1."""
+    j = pypyr.retries.jitter(sleep=100, jrc=0.1)
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+
+    assert mock_random.mock_calls == [call(10, 100),
+                                      call(10, 100),
+                                      call(10, 100)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_single_jrc_up(mock_random):
+    """Jitter with single float input and jrc > 1."""
+    j = pypyr.retries.jitter(sleep=100, jrc=3.5)
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+
+    assert mock_random.mock_calls == [call(350, 100),
+                                      call(350, 100),
+                                      call(350, 100)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_jitter_list_jrc_up_max(mock_random):
+    """Jitter with list float input and jrc > 1 ignore max."""
+    j = pypyr.retries.jitter(sleep=[100, 200, 300], jrc=2, max_sleep=200)
+    assert j(0) == 999
+    assert j(1) == 999
+    assert j(2) == 999
+    assert j(1) == 999
+
+    assert mock_random.mock_calls == [call(200, 100),
+                                      call(400, 200),
+                                      call(400, 200),
+                                      call(400, 200)]
+# endregion jitter
+
+# region linear
+
+
+def test_retries_linear():
+    """Linear retry works."""
+    lr = pypyr.retries.linear()
+    assert lr(0) == 0
+    assert lr(1) == 1
+    assert lr(2) == 2
+    assert lr(3) == 3
+    assert lr(1) == 1
+
+
+def test_retries_linear_with_max():
+    """Linear retry works."""
+    lr = pypyr.retries.linear(sleep=2, max_sleep=8)
+    assert lr(0) == 0
+    assert lr(1) == 2
+    assert lr(2) == 4
+    assert lr(3) == 6
+    assert lr(4) == 8
+    assert lr(5) == 8
+    assert lr(10) == 8
+    assert lr(1) == 2
+
+# endregion linear
+
+
+# region linearjitter
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_linearjitter(mock_random):
+    """Linearjitter linear progression."""
+    lj = pypyr.retries.linearjitter(sleep=3)
+    assert lj(1) == 999
+    assert lj(2) == 999
+    assert lj(3) == 999
+    assert lj(1) == 999
+
+    assert mock_random.mock_calls == [call(0, 3),
+                                      call(0, 6),
+                                      call(0, 9),
+                                      call(0, 3)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_linearjitter_max(mock_random):
+    """Linearjitter linear progression honors max."""
+    lj = pypyr.retries.linearjitter(sleep=4, max_sleep=15)
+    assert lj(1) == 999
+    assert lj(2) == 999
+    assert lj(3) == 999
+    assert lj(4) == 999
+    assert lj(2) == 999
+
+    assert mock_random.mock_calls == [call(0, 4),
+                                      call(0, 8),
+                                      call(0, 12),
+                                      call(0, 15),
+                                      call(0, 8)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_linearjitter_jrc_down(mock_random):
+    """Linearjitter linear progression with jrc < 1."""
+    lj = pypyr.retries.linearjitter(sleep=3, jrc=0.5)
+    assert lj(1) == 999
+    assert lj(2) == 999
+    assert lj(3) == 999
+    assert lj(1) == 999
+
+    assert mock_random.mock_calls == [call(1.5, 3),
+                                      call(3, 6),
+                                      call(4.5, 9),
+                                      call(1.5, 3)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_linearjitter_jrc_up(mock_random):
+    """Linearjitter linear progression with jrc > 1."""
+    lj = pypyr.retries.linearjitter(sleep=3, jrc=2)
+    assert lj(1) == 999
+    assert lj(2) == 999
+    assert lj(3) == 999
+    assert lj(1) == 999
+
+    assert mock_random.mock_calls == [call(6, 3),
+                                      call(12, 6),
+                                      call(18, 9),
+                                      call(6, 3)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_linearjitter_jrc_over_max(mock_random):
+    """Linearjitter linear progression with jrc > 1 ignores max."""
+    lj = pypyr.retries.linearjitter(sleep=3, jrc=2, max_sleep=10)
+    assert lj(1) == 999
+    assert lj(2) == 999
+    assert lj(3) == 999
+    assert lj(1) == 999
+
+    assert mock_random.mock_calls == [call(6, 3),
+                                      call(12, 6),
+                                      call(18, 9),
+                                      call(6, 3)]
+# endregion linearjitter
+
+
+# region exponential
+
+def test_retries_exponential():
+    """Exponential retry works."""
+    e = pypyr.retries.exponential()
+    assert e(0) == 1
+    assert e(1) == 2
+    assert e(2) == 4
+    assert e(3) == 8
+    assert e(4) == 16
+    assert e(1) == 2
+
+
+def test_retries_exponential_kwargs_no_base():
+    """Exponential retry works with kwargs and no base set."""
+    e = pypyr.retries.exponential(kwargs={'notbase': 3})
+    assert e(0) == 1
+    assert e(1) == 2
+    assert e(2) == 4
+    assert e(3) == 8
+    assert e(4) == 16
+    assert e(1) == 2
+
+
+def test_retries_exponential_with_sleep():
+    """Exponential retry works with sleep coefficient."""
+    e = pypyr.retries.exponential(sleep=2)
+    assert e(0) == 2
+    assert e(1) == 4
+    assert e(2) == 8
+    assert e(3) == 16
+    assert e(4) == 32
+    assert e(1) == 4
+
+
+def test_retries_exponential_base_3():
+    """Exponential retry works with different base."""
+    e = pypyr.retries.exponential(kwargs={'base': 3})
+    assert e(0) == 1
+    assert e(1) == 3
+    assert e(2) == 9
+    assert e(3) == 27
+    assert e(4) == 81
+    assert e(1) == 3
+
+
+def test_retries_exponential_with_max():
+    """Exponential retry works with max."""
+    e = pypyr.retries.exponential(max_sleep=15)
+    assert e(0) == 1
+    assert e(1) == 2
+    assert e(2) == 4
+    assert e(3) == 8
+    assert e(4) == 15
+    assert e(5) == 15
+    assert e(1) == 2
+
+# endregion exponential
+
+# region exponentialjitter
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_exponentialjitter(mock_random):
+    """Exponentialjitter retry works."""
+    ej = pypyr.retries.exponentialjitter()
+    assert ej(0) == 999
+    assert ej(1) == 999
+    assert ej(2) == 999
+    assert ej(3) == 999
+    assert ej(4) == 999
+    assert ej(1) == 999
+    assert ej(8) == 999
+
+    assert mock_random.mock_calls == [call(0, 1),
+                                      call(0, 2),
+                                      call(0, 4),
+                                      call(0, 8),
+                                      call(0, 16),
+                                      call(0, 2),
+                                      call(0, 256)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_exponentialjitter_jrc_down(mock_random):
+    """Exponentialjitter retry works with jrc lower range."""
+    ej = pypyr.retries.exponentialjitter(jrc=0.5)
+    assert ej(0) == 999
+    assert ej(1) == 999
+    assert ej(2) == 999
+    assert ej(3) == 999
+    assert ej(4) == 999
+    assert ej(1) == 999
+    assert ej(8) == 999
+
+    assert mock_random.mock_calls == [call(0.5, 1),
+                                      call(1, 2),
+                                      call(2, 4),
+                                      call(4, 8),
+                                      call(8, 16),
+                                      call(1, 2),
+                                      call(128, 256)]
+
+
+@patch('pypyr.retries.random.uniform', return_value=999)
+def test_retries_exponentialjitter_jrc_up_max(mock_random):
+    """Exponentialjitter retry works with jrc upper range."""
+    ej = pypyr.retries.exponentialjitter(jrc=2)
+    assert ej(0) == 999
+    assert ej(1) == 999
+    assert ej(2) == 999
+    assert ej(3) == 999
+    assert ej(4) == 999
+    assert ej(1) == 999
+    assert ej(8) == 999
+
+    assert mock_random.mock_calls == [call(2, 1),
+                                      call(4, 2),
+                                      call(8, 4),
+                                      call(16, 8),
+                                      call(32, 16),
+                                      call(4, 2),
+                                      call(512, 256)]
+# endregion exponentialjitter
+
+# endregion retry strategies
+
+
+def test_backoff_export_list():
+    """The backoff export list should have all BackOffBase children.
+
+    If you've added a new back-off strategy, add it to the look-up dict:
+    pypyr.retries.builtin_backoffs.
+    """
+    members = inspect.getmembers(
+        pypyr.retries,
+        lambda m: inspect.isclass(m) and
+        issubclass(m, pypyr.retries.BackoffBase))
+
+    assert pypyr.retries.builtin_backoffs == {
+        n[0]: n[1] for n in members if n[0] != 'BackoffBase'}

--- a/tests/unit/pypyr/utils/poll_test.py
+++ b/tests/unit/pypyr/utils/poll_test.py
@@ -4,7 +4,7 @@ from unittest.mock import call, MagicMock, patch
 import pypyr.utils.poll as poll
 
 
-# ----------------- wait_until_true -------------------------------------------
+# region wait_until_true
 from tests.common.utils import patch_logger
 
 
@@ -25,10 +25,7 @@ def test_wait_until_true_with_static_decorator(mock_time_sleep):
         """Test static decorator syntax."""
         assert arg1 == 'v1'
         assert arg2 == 'v2'
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert decorate_me('v1', 'v2')
     assert mock.call_count == 4
@@ -53,10 +50,7 @@ def test_wait_until_true_invoke_inline(mock_time_sleep):
         """Test static decorator syntax."""
         assert arg1 == 'v1'
         assert arg2 == 'v2'
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert poll.wait_until_true(interval=0.01, max_attempts=10)(
         decorate_me)('v1', 'v2')
@@ -88,10 +82,7 @@ def test_wait_until_true_with_timeout(mock_time_sleep):
         """Test static decorator syntax."""
         assert arg1 == 'v1'
         assert arg2 == 'v2'
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert not poll.wait_until_true(interval=0.01, max_attempts=10)(
         decorate_me)('v1', 'v2')
@@ -114,10 +105,7 @@ def test_wait_until_true_once_not_found(mock_time_sleep):
         """Test static decorator syntax."""
         assert arg1 == 'v1'
         assert arg2 == 'v2'
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert not poll.wait_until_true(interval=0.01, max_attempts=1)(
         decorate_me)('v1', 'v2')
@@ -138,19 +126,16 @@ def test_wait_until_true_once_found(mock_time_sleep):
         """Test static decorator syntax."""
         assert arg1 == 'v1'
         assert arg2 == 'v2'
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert poll.wait_until_true(interval=0.01, max_attempts=1)(
         decorate_me)('v1', 'v2')
     mock.assert_called_once_with('v1')
     mock_time_sleep.assert_not_called()
 
-# ----------------- wait_until_true -------------------------------------------
+# endregion wait_until_true
 
-# ----------------- while_until_true -------------------------------------
+# region while_until_true
 
 
 @patch('time.sleep')
@@ -175,16 +160,13 @@ def test_while_until_true_with_static_decorator(mock_time_sleep):
         nonlocal actual_counter
         actual_counter += 1
         assert actual_counter == counter
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
+    # the decorator injects the 1st arg (counter)
     assert decorate_me('v1', 'v2')
     assert mock.call_count == 4
     mock.assert_called_with('v1')
-    assert mock_time_sleep.call_count == 3
-    mock_time_sleep.assert_called_with(0.01)
+    assert mock_time_sleep.mock_calls == [call(0.01), call(0.01), call(0.01)]
 
 
 @patch('time.sleep')
@@ -208,17 +190,13 @@ def test_while_until_true_invoke_inline(mock_time_sleep):
         nonlocal actual_counter
         actual_counter += 1
         assert actual_counter == counter
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert poll.while_until_true(interval=0.01, max_attempts=10)(
         decorate_me)('v1', 'v2')
     assert mock.call_count == 4
     mock.assert_called_with('v1')
-    assert mock_time_sleep.call_count == 3
-    mock_time_sleep.assert_called_with(0.01)
+    assert mock_time_sleep.mock_calls == [call(0.01), call(0.01), call(0.01)]
 
 
 @patch('time.sleep')
@@ -250,10 +228,7 @@ def test_while_until_true_with_exhaust(mock_time_sleep):
         assert actual_counter == counter
         out = mock(arg1)
         assert out == f'test string {counter}'
-        if out == 'expected value':
-            return True
-        else:
-            return False
+        return out == 'expected value'
 
     assert not poll.while_until_true(interval=0.01, max_attempts=10)(
         decorate_me)('v1', 'v2')
@@ -281,10 +256,7 @@ def test_while_until_true_once_not_found(mock_time_sleep):
         nonlocal actual_counter
         actual_counter += 1
         assert actual_counter == counter
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert not poll.while_until_true(interval=0.01, max_attempts=1)(
         decorate_me)('v1', 'v2')
@@ -310,10 +282,7 @@ def test_while_until_true_once_found(mock_time_sleep):
         nonlocal actual_counter
         actual_counter += 1
         assert actual_counter == counter
-        if mock(arg1) == 'expected value':
-            return True
-        else:
-            return False
+        return mock(arg1) == 'expected value'
 
     assert poll.while_until_true(interval=0.01, max_attempts=1)(
         decorate_me)('v1', 'v2')
@@ -350,10 +319,7 @@ def test_while_until_true_no_max(mock_time_sleep):
         assert actual_counter == counter
         out = mock(arg1)
         assert out == f'test string {counter}'
-        if out == 'test string 11':
-            return True
-        else:
-            return False
+        return out == 'test string 11'
 
     with patch_logger('pypyr.utils.poll', logging.DEBUG) as mock_logger_debug:
         assert (poll.while_until_true(interval=0.01,
@@ -362,16 +328,16 @@ def test_while_until_true_no_max(mock_time_sleep):
     assert mock_logger_debug.mock_calls == [
         call('started'),
         call('Looping every 0.01 seconds.'),
-        call('iteration 1. Still waiting. . .'),
-        call('iteration 2. Still waiting. . .'),
-        call('iteration 3. Still waiting. . .'),
-        call('iteration 4. Still waiting. . .'),
-        call('iteration 5. Still waiting. . .'),
-        call('iteration 6. Still waiting. . .'),
-        call('iteration 7. Still waiting. . .'),
-        call('iteration 8. Still waiting. . .'),
-        call('iteration 9. Still waiting. . .'),
-        call('iteration 10. Still waiting. . .'),
+        call('iteration 1. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 2. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 3. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 4. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 5. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 6. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 7. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 8. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 9. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 10. Sleeping for 0.01s. Still waiting...'),
         call('iteration 11. Desired state reached.'),
         call('done')]
 
@@ -411,13 +377,52 @@ def test_while_until_true_max_exhaust(mock_time_sleep):
     assert mock_logger_debug.mock_calls == [
         call('started'),
         call('Looping every 0.01 seconds for 3 attempts'),
-        call('iteration 1. Still waiting. . .'),
-        call('iteration 2. Still waiting. . .'),
+        call('iteration 1. Sleeping for 0.01s. Still waiting...'),
+        call('iteration 2. Sleeping for 0.01s. Still waiting...'),
         call('iteration 3. Max attempts exhausted.'),
         call('done')]
 
     assert mock.call_count == 3
     mock.assert_called_with('v1')
     assert mock_time_sleep.call_count == 2
-    mock_time_sleep.assert_called_with(0.01)
-# ----------------- while_until_true -------------------------------------
+    assert mock_time_sleep.mock_calls == [call(0.01), call(0.01)]
+
+
+def arb_callable(n):
+    """Arb callable for testing."""
+    return n * 2
+
+
+@patch('time.sleep')
+def test_while_until_true_callable_with_max_attempts(mock_sleep):
+    """Interval calculated from callable per iteration with max set."""
+    decorate_me = MagicMock()
+    decorate_me.side_effect = [False, False, True, False]
+
+    assert poll.while_until_true(interval=arb_callable,
+                                 max_attempts=3)(decorate_me)('arg1', 'arg2')
+
+    assert decorate_me.mock_calls == [call(1, 'arg1', 'arg2'),
+                                      call(2, 'arg1', 'arg2'),
+                                      call(3, 'arg1', 'arg2')]
+
+    assert mock_sleep.mock_calls == [call(2), call(4)]
+
+
+@patch('time.sleep')
+def test_while_until_true_callable_without_max_attempts(mock_sleep):
+    """Interval calculated from callable per iteration infinite."""
+    decorate_me = MagicMock()
+    decorate_me.side_effect = [False, False, False, True, False]
+
+    assert poll.while_until_true(interval=arb_callable,
+                                 max_attempts=None)(decorate_me)('arg1',
+                                                                 'arg2')
+
+    assert decorate_me.mock_calls == [call(1, 'arg1', 'arg2'),
+                                      call(2, 'arg1', 'arg2'),
+                                      call(3, 'arg1', 'arg2'),
+                                      call(4, 'arg1', 'arg2')]
+
+    assert mock_sleep.mock_calls == [call(2), call(4), call(6)]
+# endregion while_until_true


### PR DESCRIPTION
- Add retry backoff strategies. #216.
  - the `while_until_true` looper now also accepts a `callable` to calculate sleep interval for the `sleep` interval. You can still pass a `float`, so this is fully backwards compatible.
- the retry poller confused coverage with evaluating the `while bool_here` dynamically, necessitating nopragma. The loops in question all `break` explicitly for all possible exit conditions that break out of loop, so the extra while eval condition not actually necessary. Thus, remove & simplify. No functional change.