### PR TITLE
cleaner api initialization

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,6 @@ http://doc.pytest.org/en/latest/example/simple.html#package-directory-level-fixt
 """
 import logging
 
-from pypyr.log.logger import set_root_logger, set_up_notify_log_level
+from pypyr.log.logger import set_root_logger
 
-set_up_notify_log_level()
 set_root_logger(logging.DEBUG)

--- a/pypyr/__init__.py
+++ b/pypyr/__init__.py
@@ -1,1 +1,8 @@
-"""init py module."""
+"""Initialize the pypyr package.
+
+The most notable side-effect of importing this is package is that it adds a
+NOTIFY (25) log level and notify() method to the global logger object.
+"""
+import pypyr.log.logger
+
+pypyr.log.logger.set_up_notify_log_level()

--- a/pypyr/cache/cache.py
+++ b/pypyr/cache/cache.py
@@ -15,7 +15,7 @@ class Cache():
 
     def __init__(self):
         """Instantiate the cache."""
-        self._lock = threading.RLock()
+        self._lock = threading.Lock()
         self._cache = {}
 
     def clear(self):
@@ -31,7 +31,7 @@ class Cache():
         If key is not found, call creator and save the result to cache for that
         key.
 
-        Be warned that get happens under the context of a RLock. . . so if
+        Be warned that get happens under the context of a Lock. . . so if
         creator takes a long time you might well be blocking.
 
         Args:

--- a/pypyr/log/logger.py
+++ b/pypyr/log/logger.py
@@ -1,4 +1,4 @@
-"""Continous Deployment logging functions.
+"""Logging functions for pypyr.
 
 Configuration for the python logging library.
 """
@@ -41,6 +41,10 @@ def set_up_notify_log_level():
     NOTIFY severity is logging level between INFO and WARNING.
     By default it outputs only echo step and step name
     with description.
+
+    This function should run once and only once
+    at the initialization of pypyr. You shouldn't need to do so yourself, it's
+    called from package init.
     """
     # could (should?) be checking hasattr like so:
     # hasattr(logging, levelName):

--- a/pypyr/pipelinerunner.py
+++ b/pypyr/pipelinerunner.py
@@ -221,11 +221,9 @@ def prepare_and_run(
     call. It's called from the main() entrypoint.
 
     You probably shouldn't call me directly yourself, use main() or
-    main_with_context() instead. This function should run once and only once
-    at the initialization of pypyr.
+    main_with_context() instead.
 
     This function does this:
-    - add NOTIFY log level
     - configure working directory
     - load & run the pipeline
     - handle Stop instructions
@@ -252,8 +250,6 @@ def prepare_and_run(
         None
 
     """
-    pypyr.log.logger.set_up_notify_log_level()
-
     logger.debug("starting pypyr")
 
     # pipelines specify steps in python modules that load dynamically.

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.4.1'
+__version__ = '4.5.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.4.1
+current_version = 4.5.0
 
 [bumpversion:file:pypyr/version.py]
 

--- a/tests/unit/pypyr/__init__test.py
+++ b/tests/unit/pypyr/__init__test.py
@@ -1,0 +1,14 @@
+from unittest.mock import call
+
+# the entire point is to test imports when import package, even when not used.
+import pypyr  # noqa: F401
+from tests.common.utils import patch_logger
+
+
+def test_init_package():
+    """Import pypyr runs one off initialization code."""
+    import logging
+    with patch_logger(__name__, logging.NOTIFY) as mock_log:
+        logging.getLogger(__name__).notify("arb")
+
+    assert mock_log.mock_calls == [call('arb')]

--- a/tests/unit/pypyr/log/logger_test.py
+++ b/tests/unit/pypyr/log/logger_test.py
@@ -59,11 +59,11 @@ def test_logger_with_file_and_console_handler():
 
 def test_notify_log_level_available():
     """Notify log level added."""
-    # actually redundant, coz ./conftest.py actually already calls
+    # actually redundant, coz __init__ on pypyr package import already calls
     # set_up_notify_log_level. Might as well test re-entrancy then, thus:
     pypyr.log.logger.set_up_notify_log_level()
 
-    assert logging.INFO < logging.NOTIFY < logging.WARNING
+    assert logging.DEBUG < logging.INFO < logging.NOTIFY < logging.WARNING
 
     logger = logging.getLogger('pypyr')
     with patch_logger('pypyr', logging.NOTIFY) as mock_logger_notify:

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -115,7 +115,7 @@ def test_main_pass(mocked_get_mocked_work_dir,
                               failure_group='fg',
                               loader='arb loader')
 
-    mocked_set_up_notify.assert_called_once()
+    mocked_set_up_notify.assert_not_called()
     mocked_set_work_dir.assert_called_once_with('arb/dir')
     mocked_run_pipeline.assert_called_once_with(
         pipeline_name='arb pipe',
@@ -128,19 +128,16 @@ def test_main_pass(mocked_get_mocked_work_dir,
         failure_group='fg')
 
 
-@patch('pypyr.log.logger.set_up_notify_log_level')
 @patch('pypyr.pipelinerunner.load_and_run_pipeline')
 @patch('pypyr.moduleloader.set_working_directory')
 @patch('pypyr.moduleloader.get_working_directory', return_value='arb/dir')
 def test_main_with_minimal(mocked_get_mocked_work_dir,
                            mocked_set_work_dir,
-                           mocked_run_pipeline,
-                           mocked_set_up_notify):
+                           mocked_run_pipeline):
     """Main initializes and runs pipelines with minimal input."""
     pipeline_cache.clear()
     pypyr.pipelinerunner.main(pipeline_name='arb pipe')
 
-    mocked_set_up_notify.assert_called_once()
     mocked_set_work_dir.assert_called_once_with(None)
     mocked_run_pipeline.assert_called_once_with(
         pipeline_name='arb pipe',
@@ -206,7 +203,7 @@ def test_main_with_context_pass(mocked_get_mocked_work_dir,
     assert out.pipeline_name == 'arb pipe'
     assert out.working_dir == 'arb/dir'
 
-    mocked_set_up_notify.assert_called_once()
+    mocked_set_up_notify.assert_not_called()
     mocked_set_work_dir.assert_called_once_with('arb/dir')
     mocked_run_pipeline.assert_called_once_with(
         pipeline_name='arb pipe',
@@ -219,14 +216,12 @@ def test_main_with_context_pass(mocked_get_mocked_work_dir,
         failure_group='fg')
 
 
-@patch('pypyr.log.logger.set_up_notify_log_level')
 @patch('pypyr.pipelinerunner.load_and_run_pipeline')
 @patch('pypyr.moduleloader.set_working_directory')
 @patch('pypyr.moduleloader.get_working_directory', return_value='arb/dir')
 def test_main_with_context_minimal(mocked_get_mocked_work_dir,
                                    mocked_set_work_dir,
-                                   mocked_run_pipeline,
-                                   mocked_set_up_notify):
+                                   mocked_run_pipeline):
     """Main with context with minimal args."""
     pipeline_cache.clear()
     out = pypyr.pipelinerunner.main_with_context(pipeline_name='arb pipe')
@@ -236,7 +231,6 @@ def test_main_with_context_minimal(mocked_get_mocked_work_dir,
     assert out.pipeline_name == 'arb pipe'
     assert out.working_dir == 'arb/dir'
 
-    mocked_set_up_notify.assert_called_once()
     mocked_set_work_dir.assert_called_once_with(None)
     mocked_run_pipeline.assert_called_once_with(
         pipeline_name='arb pipe',


### PR DESCRIPTION
- prevent duplicates in `sys.path` (#218) on main* api entry points. thread-safe existence check on `sys.path` list.
- prevent redundant multiple addition of notify log-level on main* api entry. Move initialization code to package `__init__`.
- version bump for minor new release