### PR TITLE
Ensure cmd runs with LANG=C to fix #224

### DIFF
--- a/tests/unit/pypyr/steps/cmd_step_test.py
+++ b/tests/unit/pypyr/steps/cmd_step_test.py
@@ -8,6 +8,14 @@ import pytest
 import subprocess
 
 
+@pytest.fixture(autouse=True)
+def lang_c(monkeypatch):
+    """Ensure commands print messages in English
+    Without this, running tests in non-english locale print unexpected messages
+    """
+    monkeypatch.setenv("LANG", "C")
+
+
 def test_cmd_single_word():
     """One word command works."""
     context = Context({'cmd': 'date'})


### PR DESCRIPTION
Set LANG=C for test validating error message to ensure the message is in English and not in locale of currently used OS.

Done module-wide (autouse=True) fixture.