### PR TITLE
DO NOT MERGE: Experimental rewrite of ops to invoke

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,0 +1,8 @@
+package_name: pypyr
+test_dir: tests
+version_module_name: pypyr.version
+output_results_dir: .test-results
+# output_coverage: xml:{output_results_dir}/codecoverage/coverage.xml
+# output_coverage: xml:.test-results/codecoverage/coverage.xml
+# output_test_results: "{output_results_dir}/testresults/junitresults.xml"
+argList: null

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -2,6 +2,7 @@ package_name: pypyr
 test_dir: tests
 version_module_name: pypyr.version
 output_results_dir: .test-results
+## following values are calculated by ops/config.py task
 # output_coverage: xml:{output_results_dir}/codecoverage/coverage.xml
 # output_coverage: xml:.test-results/codecoverage/coverage.xml
 # output_test_results: "{output_results_dir}/testresults/junitresults.xml"

--- a/ops/README.rst
+++ b/ops/README.rst
@@ -1,0 +1,206 @@
+========================
+CI/CD tools using invoke
+========================
+This directory (+ ../tasks.py + ../invoke.yaml) contain experimental implementation of the same 
+pipelines as pypyr uses for it's own build, but using invoke_.
+
+The idea is to implement all, what is in ops/*.yaml files in pure invoke. This
+shall allow to compare pypyr to invoke tooling.
+
+.. _invoke: http://docs.pyinvoke.org/en/stable/
+
+
+Prerequisities
+==============
+It expects required tools to be available. Most of the tools can be installed
+globally in the system as they can be used as any other CLI.
+
+These tools include:
+- invoke
+- flake8
+- twine
+- pytest (must be instaleled within virtualenv)
+- codecov (must be probably instaleled within virtualenv)
+
+Installation
+============
+Ensure all the CLI tools are installed.
+
+Currently we expect invoke to be part of virtual env.
+
+Configuration
+=============
+See file `invoke.yaml`
+
+If you want to use private pypi, such as devpi-server, set env vars for twine and pip, e.g.::
+
+  export TWINE_REPOSITORY_URL=http://10.0.0.1:3141/username/dev
+  export TWINE_USERNAME=username
+  export TWINE_PASSWORD=somepassword
+  export PIP_INDEX_URL=$TWINE_REPOSITORY_URL
+
+Usage
+=====
+To list all available invoke tasks::
+
+  $ inv -l
+  Available tasks:
+
+    config                  Complete and validate needed cfg.
+    package                 Run all package build tasks.
+    pipeline-buildout       Lint and test.
+    lint.all                Run all lint tasks.
+    lint.flake8             flake8 linting.
+    lint.setup-meta         Verify setup.py metadata.
+    publish.all             Publish built packages to (public or private) pypi.
+    test.all                Run all CI/CD either in local or remote (CI/CD
+                            server) mode.
+    test.codecov            Coverage (possibly with result upload).
+    test.test-to-file       tests, output to file.
+    test.test-to-terminal   tests, output to terminal with line nos.
+
+To show help for particular task, e.g. for `lint.flake8`::
+
+  inv lint.flake8 --help
+  Usage: inv[oke] [--core-opts] lint.flake8 [other tasks here ...]
+
+  Docstring:
+    flake8 linting.
+
+  Options:
+    none
+
+To call particular task, e.g. lint.flake8::
+
+  $ inv lint.flake8
+  ==> ops.lint.flake8: flake8 linting.
+  <==: OK (ops.lint.flake8)
+
+
+To run complete pipeline such as `pipeline-buidout`::
+
+  $ inv pipeline-buildout
+  ==> ops.lint.all: Run all lint tasks.
+  ==> ops.lint.setup_meta: Verify setup.py metadata.
+  running check
+  <==: OK (ops.lint.setup_meta)
+  ==> ops.lint.flake8: flake8 linting.
+  <==: OK (ops.lint.flake8)
+  <==: OK (ops.lint.all)
+  ==> ops.config.all: Complete and validate needed cfg.
+  <==: OK (ops.config.all)
+  ==> ops.test.all: Run all CI/CD either in local or remote (CI/CD server) mode.
+  ==> ops.test.test_to_terminal: tests, output to terminal with line nos.
+  ============================= test session starts ==============================
+  platform linux -- Python 3.9.1, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+  rootdir: /home/javl/sandbox/pypyr/github-repo/pypyr, configfile: tox.ini
+  plugins: cov-2.12.1
+  collected 1157 items
+
+  tests/integration/pypyr/errorhandling_int_test.py ................       [  1%]
+  tests/integration/pypyr/pipelinerunner_int_test.py ..............        [  2%]
+  tests/integration/pypyr/call/loopcallnested_int_test.py ..........       [  3%]
+  tests/integration/pypyr/jump/loopjumpnested_int_test.py .                [  3%]
+  tests/unit/pypyr/__main__test.py .                                       [  8%]
+  tests/unit/pypyr/cli_test.py .................                           [ 10%]
+  .....(truncated)....
+  tests/unit/pypyr/utils/asserts_test.py .............                     [ 97%]
+  tests/unit/pypyr/utils/filesystem_test.py .......                        [ 98%]
+  tests/unit/pypyr/utils/poll_test.py ..............                       [ 99%]
+  tests/unit/pypyr/utils/types_test.py .......                             [100%]
+
+  ----------- coverage: platform linux, python 3.9.1-final-0 -----------
+  Name    Stmts   Miss Branch BrPart  Cover   Missing
+  ---------------------------------------------------
+  ---------------------------------------------------
+  TOTAL    2350      0    639      0   100%
+
+  82 files skipped due to complete coverage.
+
+  Required test coverage of 100.0% reached. Total coverage: 100.00%
+
+  ============================= 1157 passed in 9.73s =============================
+  <==: OK (ops.test.test_to_terminal)
+  <==: OK (ops.test.all)
+  ==> tasks.pipeline_buildout: Lint and test.
+  <==: OK (tasks.pipeline_buildout)
+
+Challenges
+==========
+Can we minimize installing dependencies of these tools into actual python
+virtual env used for the package?
+
+Invoke lessons learned
+======================
+
+Easy access to particular tasks
+-------------------------------
+The::
+
+  $ inv -l
+
+provides nice task listing + it allows to pick any of them and call as developer needs.
+
+Tasks to be called independently
+--------------------------------
+If any tasks shall be called independently, it must be defined as separate `@task`.
+
+Grouping (sub) tasks into single task shorten the code
+------------------------------------------------------
+In many cases there is no need to have independent task for each call to a CLI.
+
+Putting multiple calls into single `@task` makes code shorter and simpler to read.
+
+To make these sub-steps better visible in output, use `ops.step` to print what is goning on::
+
+  from ops import step
+
+
+  @task
+  def magic(c):
+      step("get magic stick")
+      stick = get_magic_stick("wooden one")
+
+      step("do the magic")
+      stick.do_the_magic("now")
+
+The `step` will produce lines such as::
+
+  --> get magic stick
+  --> do the magic
+
+Fixing invoke limited task reporting on output
+----------------------------------------------
+By default, invoke prints something to stdout, but often it is not clear, which task was started and how it finished.
+
+For this reason, `MyTask` class was added (see `ops/__init__.py`) which extends `__call__` to do some handy printing.
+
+invoke.call causes forgotten pre-tasks runs
+-------------------------------------------
+One can call another task directly, e.g.::
+
+  from invoke import call
+  from . import othertasks
+
+  @task
+  def lint(c):
+      call(othertasks.checkmeta).task(c)
+
+However - if the othertasks.checkmeta declares some pre-tasks to be run, the `call` ignores them.
+
+To run the pre-tasks, do declare the task `othertasks.checketa` as pre-task, e.g.::
+
+  from invoke import call
+  from . import othertasks
+
+  @task(othertasks.checkmeta)
+  def lint(c):
+    pass
+
+`invoke.task` is not easy to decorate or modify
+-----------------------------------------------
+The idea was to replace `@task(klass=MyTask)` by easier to use `@mytask`.
+
+However, it turns out that the `invoke.task` decorator is not easy to decorate or to use with `functools.partial`.
+
+

--- a/ops/README.rst
+++ b/ops/README.rst
@@ -49,6 +49,11 @@ To list all available invoke tasks::
     config                  Complete and validate needed cfg.
     package                 Run all package build tasks.
     pipeline-buildout       Lint and test.
+    pipeline-bumpversion    Bump the version and git push.
+    pipeline-tag            Tag the commit on GitHub actions server.
+    show-version            Print current package version.
+    bump.bumpversion        Bump the package version.
+    bump.git-push           Push the new version up (git).
     lint.all                Run all lint tasks.
     lint.flake8             flake8 linting.
     lint.setup-meta         Verify setup.py metadata.
@@ -58,6 +63,7 @@ To list all available invoke tasks::
     test.codecov            Coverage (possibly with result upload).
     test.test-to-file       tests, output to file.
     test.test-to-terminal   tests, output to terminal with line nos.
+
 
 To show help for particular task, e.g. for `lint.flake8`::
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,0 +1,6 @@
+"""Invoke task modules, one per namespace."""
+
+
+def step(msg):
+    """Print a message in such a way, it is visible in longer console outputs."""
+    print(f"--> {msg}")

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,6 +1,45 @@
 """Invoke task modules, one per namespace."""
+import functools
+
+from invoke import Task, task
 
 
-def step(msg):
+def step(msg=None):
     """Print a message in such a way, it is visible in longer console outputs."""
     print(f"--> {msg}")
+
+
+class MyTask(Task):
+    """Customized invoke Task reporting it's call."""
+
+    def __call__(self, *args, **kwargs):
+        """Run the actual task."""
+        self.report_call()
+        try:
+            result = super().__call__(*args, **kwargs)
+            self.report_success()
+            return result
+        except Exception as exc:
+            self.report_failure(exc)
+            raise
+
+    def report_call(self):
+        """Print the fact the task is called."""
+        module = self.__module__
+        doc = self.__doc__ or ""
+        doc = doc.splitlines()[0]
+        print(f"==> {module}.{self.name}: {doc}")
+
+    def report_success(self):
+        """Print OK."""
+        module = self.__module__
+        print(f"<==: OK ({module}.{self.name})")
+
+    def report_failure(self, exc):
+        """Print FAILURE + first line of error message, if any."""
+        module = self.__module__
+        msg = str(exc).splitlines()[0]
+        print(f"<==: FAILURE ({module}.{self.name}): {msg}")
+
+
+mytask = functools.partial(task, klass=MyTask)

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,7 +1,6 @@
 """Invoke task modules, one per namespace."""
-import functools
 
-from invoke import Task, task
+from invoke import Task
 
 
 def step(msg=None):
@@ -42,4 +41,14 @@ class MyTask(Task):
         print(f"<==: FAILURE ({module}.{self.name}): {msg}")
 
 
-mytask = functools.partial(task, klass=MyTask)
+def get_version(version_module_name):
+    """Load currently declared package version."""
+    import importlib
+
+    version_module = importlib.import_module(version_module_name)
+    # always reload
+    importlib.reload(version_module)
+
+    version = f"{version_module.__version__}"
+    print(f"version is {version}")
+    return version

--- a/ops/bump.py
+++ b/ops/bump.py
@@ -1,0 +1,33 @@
+"""Bumping package version."""
+from invoke import call, task
+
+from . import MyTask, config, pipeline_buildout, step
+
+
+@task(
+    pipeline_buildout.buildout,
+    klass=MyTask,
+    help={
+        "bump_size": (
+            "Part of version to bump. "
+            "One of [major, minor, patch]. "
+            "Default: patch"
+        )
+    },
+)
+def bumpversion(c, bump_size="patch"):
+    """Bump the package version."""
+    step("bump_size expects major, minor or patch")
+    assert bump_size in ["major", "minor", "patch"]
+
+    step("bumping version")
+    c.run(f"bumpversion --no-tag  --commit {bump_size}")
+
+    step("report new version")
+    call(config.show_version).task(c)
+
+
+@task(klass=MyTask)
+def git_push(c):
+    """Push the new version up (git)."""
+    c.run("git push")

--- a/ops/config.py
+++ b/ops/config.py
@@ -7,8 +7,10 @@ import os
 
 from invoke import task
 
+from . import MyTask
 
-@task
+
+@task(klass=MyTask)
 def all(c):
     """Complete and validate needed cfg.
 
@@ -16,7 +18,7 @@ def all(c):
 
     May perform some validation.
 
-    Must be set as @task(pre=[configure]) on relevant task to take effect.
+    Must be set as @task(configure]) on relevant task to take effect.
     """
     cfg = c.config
     expected_keys = ["package_name", "version_module_name", "output_results_dir"]
@@ -26,19 +28,3 @@ def all(c):
     cfg.output_test_results = f"{cfg.output_results_dir}/testresults/junitresults.xml"
     is_ci = bool(os.environ.get("CI", False))
     cfg.is_ci = is_ci
-
-
-@task
-def version(c):
-    """Load currently declared package version."""
-    import importlib
-
-    cfg = c.config
-
-    version_module = importlib.import_module(c.config.version_module_name)
-    if "is_version_module_loaded" in cfg:
-        importlib.reload(version_module)
-
-    cfg.version = f"{version_module.__version__}"
-    cfg.is_version_module_loaded = True
-    print(f"version is {c.config.version}")

--- a/ops/config.py
+++ b/ops/config.py
@@ -7,7 +7,7 @@ import os
 
 from invoke import task
 
-from . import MyTask
+from . import MyTask, get_version
 
 
 @task(klass=MyTask)
@@ -28,3 +28,10 @@ def all(c):
     cfg.output_test_results = f"{cfg.output_results_dir}/testresults/junitresults.xml"
     is_ci = bool(os.environ.get("CI", False))
     cfg.is_ci = is_ci
+
+
+@task(klass=MyTask)
+def show_version(c):
+    """Print current package version."""
+    version = get_version(c.version_module_name)
+    print(f"current package version: {version}")

--- a/ops/config.py
+++ b/ops/config.py
@@ -1,0 +1,44 @@
+"""Internal tasks managing configuration.
+
+Intended as pre-tasks.
+
+"""
+import os
+
+from invoke import task
+
+
+@task
+def all(c):
+    """Complete and validate needed cfg.
+
+    Modifies `c.config` by adding needed values.
+
+    May perform some validation.
+
+    Must be set as @task(pre=[configure]) on relevant task to take effect.
+    """
+    cfg = c.config
+    expected_keys = ["package_name", "version_module_name", "output_results_dir"]
+    for key in expected_keys:
+        assert key in cfg, f"key {key} shall exist in config"
+    cfg.output_coverage = f"xml:{cfg.output_results_dir}/codecoverage/coverage.xml"
+    cfg.output_test_results = f"{cfg.output_results_dir}/testresults/junitresults.xml"
+    is_ci = bool(os.environ.get("CI", False))
+    cfg.is_ci = is_ci
+
+
+@task
+def version(c):
+    """Load currently declared package version."""
+    import importlib
+
+    cfg = c.config
+
+    version_module = importlib.import_module(c.config.version_module_name)
+    if "is_version_module_loaded" in cfg:
+        importlib.reload(version_module)
+
+    cfg.version = f"{version_module.__version__}"
+    cfg.is_version_module_loaded = True
+    print(f"version is {c.config.version}")

--- a/ops/lint.py
+++ b/ops/lint.py
@@ -1,0 +1,25 @@
+"""Lint code and package metadata."""
+from invoke import task
+
+
+@task
+def setup_meta(c):
+    """Verify setup.py metadata.
+
+    This will soon (?) deprecate in favor of twine --check.
+    For the moment twine still only checks README validity, and not
+    metadata.
+    """
+    c.run("python setup.py check -m -s")
+
+
+@task
+def flake8(c):
+    """flake8 linting."""
+    c.run("flake8")
+
+
+@task(pre=[setup_meta, flake8])
+def all(c):
+    """Run all lint tasks."""
+    pass

--- a/ops/lint.py
+++ b/ops/lint.py
@@ -1,8 +1,10 @@
 """Lint code and package metadata."""
-from invoke import task
+from invoke import call, task
+
+from . import MyTask
 
 
-@task
+@task(klass=MyTask)
 def setup_meta(c):
     """Verify setup.py metadata.
 
@@ -13,13 +15,14 @@ def setup_meta(c):
     c.run("python setup.py check -m -s")
 
 
-@task
+@task(klass=MyTask)
 def flake8(c):
     """flake8 linting."""
     c.run("flake8")
 
 
-@task(pre=[setup_meta, flake8])
+@task(klass=MyTask)
 def all(c):
     """Run all lint tasks."""
-    pass
+    call(setup_meta).task(c)
+    call(flake8).task(c)

--- a/ops/package.py
+++ b/ops/package.py
@@ -1,0 +1,24 @@
+"""Build packages."""
+from invoke import task, call
+
+
+@task
+def build_dist(c):
+    """Build wheel + sdist to dist/."""
+    c.run("python setup.py bdist_wheel sdist")
+
+
+@task
+def verify_long_description(c):
+    """verify/check new package in dist/.
+
+    verify README/long_description
+    """
+    c.run("twine check dist/*")
+
+
+@task
+def all(c):
+    """Run all package build tasks."""
+    call(build_dist).task(c)
+    call(verify_long_description).task(c)

--- a/ops/package.py
+++ b/ops/package.py
@@ -1,24 +1,15 @@
 """Build packages."""
-from invoke import task, call
+from invoke import task
+
+from . import MyTask, step
 
 
-@task
-def build_dist(c):
-    """Build wheel + sdist to dist/."""
-    c.run("python setup.py bdist_wheel sdist")
-
-
-@task
-def verify_long_description(c):
-    """verify/check new package in dist/.
-
-    verify README/long_description
-    """
-    c.run("twine check dist/*")
-
-
-@task
+@task(klass=MyTask)
 def all(c):
     """Run all package build tasks."""
-    call(build_dist).task(c)
-    call(verify_long_description).task(c)
+    step("Build wheel + sdist to dist/.")
+    c.run("python setup.py bdist_wheel sdist")
+
+    step("verify/check new package in dist/")
+    # verify README/long_description
+    c.run("twine check --strict dist/*")

--- a/ops/pipeline_buildout.py
+++ b/ops/pipeline_buildout.py
@@ -1,0 +1,10 @@
+"""All pipelines."""
+from invoke import task
+
+from . import MyTask, lint, test
+
+
+@task(lint.all, test.all, klass=MyTask)
+def buildout(c):
+    """Lint and test."""
+    pass

--- a/ops/pipeline_bump.py
+++ b/ops/pipeline_bump.py
@@ -1,0 +1,12 @@
+"""Bump version and git push."""
+from invoke import call, task
+
+from . import MyTask, bump
+
+
+@task(klass=MyTask)
+def pipeline_bump(c, bump_size=None):
+    """Bump the version and git push."""
+    c.config.bump_size = bump_size
+    call(bump.bumpversion, bump_size=bump_size).task(c)
+    call(bump.git_push)

--- a/ops/publish.py
+++ b/ops/publish.py
@@ -16,20 +16,7 @@ import time
 
 from invoke import task
 
-from . import step
-
-
-def get_version(version_module_name):
-    """Load currently declared package version."""
-    import importlib
-
-    version_module = importlib.import_module(version_module_name)
-    # always reload
-    importlib.reload(version_module)
-
-    version = f"{version_module.__version__}"
-    print(f"version is {version}")
-    return version
+from . import get_version, step
 
 
 @task

--- a/ops/publish.py
+++ b/ops/publish.py
@@ -1,0 +1,70 @@
+"""Publish built packages.
+
+Packages have to be already built and existing in dist directory.
+
+To publish to private repo, use env vars::
+
+    export TWINE_REPOSITORY_URL=http://10.0.0.1:3141/javl/dev
+    export TWINE_USERNAME=javl
+    export TWINE_PASSWORD=realpassword
+    export PIP_INDEX_URL=$TWINE_REPOSITORY_URL
+
+Alternatively, use TWINE_REPOSITORY (name of section in .pypirc) + configure
+relevant PIP_INDEX_URL.
+"""
+import time
+
+from invoke import call, task
+
+from . import config, step
+
+
+@task
+def all(c):
+    """Publish built packages to (public or private) pypi."""
+    cfg = c.config
+
+    step("check intended package version")
+    call(config.version).task(c)
+
+    step("publishing package to pypi")
+    c.run(f"twine upload dist/{cfg.package_name}-{cfg.version}*")
+
+    step(
+        "uninstall current version of package before attempting to reinstall from pypi"
+    )
+    c.run(f"pip uninstall -y {cfg.package_name}")
+
+    step("set expected version")
+    expected_version = cfg.version
+
+    step("giving pypi 10s before testing release")
+    time.sleep(10)
+
+    step("installing just published release from pypi for smoke-test")
+    max_tries = 5
+    sleep_time = 10
+    i = 1
+    cmd = f"pip install --upgrade --no-cache-dir {cfg.package_name}=={expected_version}"
+    while True:  # retry few times if problems
+        res = c.run(
+            cmd, warn=i < max_tries
+        )  # first runs tollerate failure, last one not
+        if res.ok:
+            break
+        time.sleep(sleep_time)
+
+    step("update cfg.versino from newly installed package")
+    call(config.version).task(c)
+
+    step("checking published package version as expected")
+    assert cfg.version == expected_version
+
+    step("reset the tox cache.")
+
+    # at this point, tox contains the pip compiled pypyr, rather than the -e
+    # dev install.  currently CI not smart enough to save changes to cache, but
+    # this could well change, so prevent future problems.  When running locally
+    # failing to do this will lead to surprises of not running local
+    # verification against the actual latest local.
+    c.run("pip install -e .")

--- a/ops/tag.py
+++ b/ops/tag.py
@@ -1,0 +1,41 @@
+"""Tag."""
+from invoke import call, task
+
+from . import MyTask, config, get_version, step
+
+
+@task(klass=MyTask)
+def set_git_config(c):
+    """Set git user.name and user.email for github-actions.
+
+    Meant to be run GitHub actions server, do not run locally.
+    """
+    step("setting git user.name")
+    c.run("git config user.name github-actions")
+    step("setting git user.email")
+    c.run("git config user.email github-actions@github.com")
+
+
+@task(config.all, klass=MyTask)
+def tag(c):
+    """Tag the commit on GitHub actions server."""
+    cfg = c.config
+
+    step("get current version")
+    version = get_version(cfg.version_module_name)
+
+    step("make sure local branch has latest tags from origin if local dev.")
+    if cfg.is_ci:
+        print("skipping as this step is not relevant on GitHub actions server.")
+    else:
+        c.run("git pull --tags")
+        res = c.run(f'git tag -l "v{version}"')
+        if res.stdout == f"v{version}":
+            step("skipping rest of task as the tag already exist.")
+            return
+
+    step("create new tag for release")
+    c.run(f'git tag "v{version}"')
+
+    if cfg.is_ci:
+        call(set_git_config).task(c)

--- a/ops/test.py
+++ b/ops/test.py
@@ -2,13 +2,12 @@
 
 Used as invoke namespace module.
 """
-from invoke import task
-from invoke.tasks import call
+from invoke.tasks import call, task
 
-from . import config
+from . import MyTask, config
 
 
-@task(pre=[config.all])
+@task(config.all, klass=MyTask)
 def test_to_terminal(c):
     """tests, output to terminal with line nos.
 
@@ -23,7 +22,7 @@ def test_to_terminal(c):
     c.run(cmd)
 
 
-@task(pre=[config.all])
+@task(config.all, klass=MyTask)
 def test_to_file(c):
     """tests, output to file.
 
@@ -41,7 +40,7 @@ def test_to_file(c):
     c.run(cmd)
 
 
-@task
+@task(klass=MyTask)
 def codecov(c):
     """Coverage (possibly with result upload).
 
@@ -52,7 +51,7 @@ def codecov(c):
     c.run("codecov")
 
 
-@task(pre=[config.all])
+@task(config.all, klass=MyTask)
 def all(c):
     """Run all CI/CD either in local or remote (CI/CD server) mode.
 

--- a/ops/test.py
+++ b/ops/test.py
@@ -1,0 +1,65 @@
+"""Tests (all sorts of).
+
+Used as invoke namespace module.
+"""
+from invoke import task
+from invoke.tasks import call
+
+from . import config
+
+
+@task(pre=[config.all])
+def test_to_terminal(c):
+    """tests, output to terminal with line nos.
+
+    test & coverage
+    """
+    cfg = c.config
+    cmd = (
+        f"pytest --cov={cfg.package_name} "
+        f"--cov-report term-missing:skip-covered "
+        f" {cfg.test_dir}"
+    )
+    c.run(cmd)
+
+
+@task(pre=[config.all])
+def test_to_file(c):
+    """tests, output to file.
+
+    test & coverage but with file output
+    """
+    cfg = c.config
+    print(f"output_coverage: {cfg.output_coverage}")
+    cmd = (
+        f"pytest --cov={cfg.package_name} "
+        f"--cov-report term-missing "
+        f"--cov-report {cfg.output_coverage} "
+        f"--junitxml={cfg.output_test_results}"
+        f"{cfg.test_dir}"
+    )
+    c.run(cmd)
+
+
+@task
+def codecov(c):
+    """Coverage (possibly with result upload).
+
+    Coverage upload only works like this on CI.
+
+    If you want to run local you need to give -t upload-token switch.
+    """
+    c.run("codecov")
+
+
+@task(pre=[config.all])
+def all(c):
+    """Run all CI/CD either in local or remote (CI/CD server) mode.
+
+    CI/CD mode is detected by env var CI being true.
+    """
+    if c.config.is_ci:
+        call(test_to_file).task(c)
+        call(codecov).task(c)
+    else:
+        call(test_to_terminal).task(c)

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.5.3'
+__version__ = '4.5.4'
 
 
 def get_version():

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.5.0'
+__version__ = '4.5.1'
 
 
 def get_version():

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.5.5'
+__version__ = '4.5.6'
 
 
 def get_version():

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.5.2'
+__version__ = '4.5.3'
 
 
 def get_version():

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.5.4'
+__version__ = '4.5.5'
 
 
 def get_version():

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '4.5.1'
+__version__ = '4.5.2'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.3
+current_version = 4.5.4
 
 [bumpversion:file:pypyr/version.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.1
+current_version = 4.5.2
 
 [bumpversion:file:pypyr/version.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.0
+current_version = 4.5.1
 
 [bumpversion:file:pypyr/version.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.4
+current_version = 4.5.5
 
 [bumpversion:file:pypyr/version.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.5
+current_version = 4.5.6
 
 [bumpversion:file:pypyr/version.py]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.2
+current_version = 4.5.3
 
 [bumpversion:file:pypyr/version.py]
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,19 @@
+"""Project CI/CD tools."""
+from invoke import Collection, task
+
+from ops import config, lint, package, publish, test
+
+
+@task(pre=[lint.all, test.all])
+def pipeline_buildout(c):
+    """Lint and test."""
+    pass
+
+
+ns = Collection()
+ns.add_task(pipeline_buildout)
+ns.add_collection(test)
+ns.add_collection(lint)
+ns.add_collection(config)
+ns.add_collection(package)
+ns.add_collection(publish)

--- a/tasks.py
+++ b/tasks.py
@@ -1,19 +1,26 @@
 """Project CI/CD tools."""
-from invoke import Collection, task
+from invoke import Collection
 
-from ops import MyTask, config, lint, package, publish, test
-
-
-@task(lint.all, test.all, klass=MyTask)
-def pipeline_buildout(c):
-    """Lint and test."""
-    pass
-
+from ops import (
+    bump,
+    config,
+    lint,
+    package,
+    pipeline_buildout,
+    pipeline_bump,
+    publish,
+    tag,
+    test,
+)
 
 ns = Collection()
-ns.add_task(pipeline_buildout)
+ns.add_task(tag.tag, "pipeline_tag")
+ns.add_task(pipeline_buildout.buildout, "pipeline_buildout")
+ns.add_task(pipeline_bump.pipeline_bump, "pipeline_bumpversion")
 ns.add_task(config.all, "config")
+ns.add_task(config.show_version, "show_version")
 ns.add_collection(lint)
 ns.add_collection(test)
+ns.add_collection(bump)
 ns.add_task(package.all, "package")
 ns.add_collection(publish)

--- a/tasks.py
+++ b/tasks.py
@@ -1,10 +1,10 @@
 """Project CI/CD tools."""
 from invoke import Collection, task
 
-from ops import config, lint, package, publish, test
+from ops import MyTask, config, lint, package, publish, test
 
 
-@task(pre=[lint.all, test.all])
+@task(lint.all, test.all, klass=MyTask)
 def pipeline_buildout(c):
     """Lint and test."""
     pass
@@ -12,8 +12,8 @@ def pipeline_buildout(c):
 
 ns = Collection()
 ns.add_task(pipeline_buildout)
-ns.add_collection(test)
+ns.add_task(config.all, "config")
 ns.add_collection(lint)
-ns.add_collection(config)
-ns.add_collection(package)
+ns.add_collection(test)
+ns.add_task(package.all, "package")
 ns.add_collection(publish)


### PR DESCRIPTION
To learn pypyr, I rewrote existing ops/* content to invoke as I am using invoke often and feel quite familiar with it.

This pull requests is not supposed to be accepted, I put it here to notify about possible comparison between pypyr and invoke implementation only.

For quick review, read the `ops/README.rst` file.

All stuff from ops/*.yaml is implemented in `tasks.py` and `ops/*.py` files.

GitHub actions are not modified and I am not planning to change that.

Comparing amount of code:
- pypyr ops/*.yml files: 259 lines
- tasks.py + ops/*.py + invoke.yml: 399 lines.

If I would try to have less lines, it seems feasible to get the invoke part down to 300 lines
This makes pypyr 259 lines rewritten to invoke 300 lines what seems a bit more, but still pretty close.

# Lessons learned
- pypyr turns to be a bit more succinct comparing to invoke code.
- some people might prefer coding in python as this does not require to learn any new syntax
- invoke solution allows more granular set of actions to call and is quite self-explanatory
- learning invoke in depth also requires some time
- invoke required some customization to report called tasks and steps and their results in more readable way
- the most daunting task is to design actual actions to do for build, tests and other actions and this applies to both pypyr and invoke implementation.
- pypyr surprised me by wide range of constructs usable for given purpose. First impression was it is not so easy to read but after this exercise I like the pypyr syntax more


