### PR TITLE
pypyr.steps.append & pypyr.steps.add

### DIFF
--- a/pypyr/steps/add.py
+++ b/pypyr/steps/add.py
@@ -1,0 +1,86 @@
+"""pypyr step that adds items to a set."""
+import logging
+
+from pypyr.utils.asserts import assert_key_exists, assert_key_is_truthy
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Add item(s) to a set.
+
+    Expects input:
+        add:
+            set (set or str): Add addMe to this set.
+            addMe (any): Add this item to set.
+            unpack (bool): Optional. Defaults False. If True, enumerate addMe
+                and add each item individually.
+
+    If add.set is a str, it refers to a key in context which contains a
+    set, e.g context['my_set'] = {1, 2, 3}. If no such key exists, will create
+    a set with that name and add addMe as the 1st item on the new set.
+
+    If you want to add/append to a list, use pypyr.steps.append instead.
+
+    If addMe is enumerable and you want to add its children individually, set
+    add.unpack = True.
+
+    Args:
+        context (pypyr.context.Context): Mandatory. Context is dict-like.
+            Context must contain key 'add'
+    """
+    logger.debug("started")
+
+    context.assert_key_has_value(key='add', caller=__name__)
+
+    step_input = context.get_formatted('add')
+
+    assert_key_is_truthy(obj=step_input,
+                         key='set',
+                         caller=__name__,
+                         parent='add')
+
+    assert_key_exists(obj=step_input,
+                      key='addMe',
+                      caller=__name__,
+                      parent='add')
+
+    the_set = step_input['set']
+    add_me = step_input['addMe']
+    is_update = step_input.get('unpack', None)
+
+    # default to unpack/update for lists specifically
+    # no real reason other than sort of feels like expected
+    # behavior from a pipeline perspective.
+    if is_update is None:
+        is_update = isinstance(add_me, list)
+
+    # str value means referring to a key in context rather than set instance
+    if isinstance(the_set, str):
+        existing_set = context.get(the_set, None)
+
+        if existing_set:
+            add_or_update_set(existing_set, add_me, is_update)
+        else:
+            # {x} works only f x single hashable, set(x) when x iterable
+            context[the_set] = set(add_me) if is_update else {add_me}
+    else:
+        add_or_update_set(the_set, add_me, is_update)
+
+    logger.debug("done")
+
+
+def add_or_update_set(the_set, add_me, is_update):
+    """Add or update the set.
+
+    Args:
+        the_set (set): The set to add/update
+        add_me (any): Item(s) to add to the_set
+        is_update (bool): If True does update rather than add.
+
+    Returns: None
+    """
+    if is_update:
+        the_set.update(add_me)
+    else:
+        the_set.add(add_me)

--- a/pypyr/steps/append.py
+++ b/pypyr/steps/append.py
@@ -1,0 +1,81 @@
+"""pypyr step that appends items to a mutable sequence, such as a list."""
+import logging
+
+from pypyr.utils.asserts import assert_key_exists, assert_key_is_truthy
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Append item to a mutable sequence.
+
+    Expects input:
+        append:
+            list (list or str): Add addMe to this mutable sequence.
+            addMe (any): Add this item to the list.
+            unpack (bool): Optional. Defaults False. If True, enumerate addMe
+                and append each item individually.
+
+    If append.list is a str, it refers to a key in context which contains a
+    list, e.g context['my_list'] = [1, 2, 3]. If no such key exists, will
+    create a list with that name and add addMe as the 1st item on the new list.
+
+    This is an append, not an extend, unless append.unpack = True.
+
+    If you want to add to a set, use pypyr.steps.add instead.
+
+    Args:
+        context (pypyr.context.Context): Mandatory. Context is a dictionary or
+            dictionary-like.
+            Context must contain key 'append'
+    """
+    logger.debug("started")
+
+    context.assert_key_has_value(key='append', caller=__name__)
+
+    step_input = context.get_formatted('append')
+
+    assert_key_is_truthy(obj=step_input,
+                         key='list',
+                         caller=__name__,
+                         parent='append')
+
+    assert_key_exists(obj=step_input,
+                      key='addMe',
+                      caller=__name__,
+                      parent='append')
+
+    lst = step_input['list']
+    add_me = step_input['addMe']
+    is_extend = step_input.get('unpack', False)
+
+    # str value means referring to a key in context rather than list instance
+    if isinstance(lst, str):
+        existing_sequence = context.get(lst, None)
+
+        if existing_sequence:
+            append_or_extend_list(existing_sequence, add_me, is_extend)
+        else:
+            # list(x) works only if x is iterable, [x] works when x != iterable
+            context[lst] = list(add_me) if is_extend else [add_me]
+    else:
+        # anything that supports append: list, deque, array... if not is_extend
+        append_or_extend_list(lst, add_me, is_extend)
+
+    logger.debug("started")
+
+
+def append_or_extend_list(lst, add_me, is_extend):
+    """Append or extend list.
+
+    Args:
+        lst (list-like): The list to append/extend
+        add_me (any): Item(s) to append/extend to lst
+        is_extend (bool): If True does extend rather than append.
+
+    Returns: None
+    """
+    if is_extend:
+        lst.extend(add_me)
+    else:
+        lst.append(add_me)

--- a/pypyr/utils/asserts.py
+++ b/pypyr/utils/asserts.py
@@ -73,3 +73,34 @@ def assert_key_has_value(obj, key, caller, parent=None):
             msg = f"context[{key!r}] must have a value for {caller}."
 
         raise KeyInContextHasNoValueError(msg)
+
+
+def assert_key_is_truthy(obj, key, caller, parent=None):
+    """Assert key exists in obj and evaluates truthy.
+
+    Empty string or 0 does NOT count as a value.
+
+    Error messages are structured as if obj is a pypyr Context.
+
+    Args:
+        obj (mapping): object to check for key.
+        key (any valid key type): key to check in obj
+        caller (string): calling function name - this used to construct
+                         error messages. Tip: use .__name__
+        parent (string): parent key name. Used to construct error messages to
+                         indicate the name of obj in context.
+
+    Raises:
+        ContextError: if obj is None or not iterable.
+        KeyInContextHasNoValueError: if not bool(context[key])
+        KeyNotInContextError: Key doesn't exist
+    """
+    assert_key_exists(obj, key, caller, parent)
+    if not obj[key]:
+        if parent:
+            msg = (f"context[{parent!r}][{key!r}] must have a value for "
+                   f"{caller}.")
+        else:
+            msg = f"context[{key!r}] must have a value for {caller}."
+
+        raise KeyInContextHasNoValueError(msg)

--- a/tests/unit/pypyr/steps/add_test.py
+++ b/tests/unit/pypyr/steps/add_test.py
@@ -1,0 +1,376 @@
+"""add.py unit tests."""
+import pytest
+
+from pypyr.context import Context
+from pypyr.dsl import PyString
+from pypyr.errors import (ContextError,
+                          KeyInContextHasNoValueError,
+                          KeyNotInContextError)
+from pypyr.steps import add
+
+
+# region validation
+def test_add_no_input():
+    """Context add must exist."""
+    with pytest.raises(KeyNotInContextError):
+        add.run_step(Context())
+
+
+def test_add_not_a_dict():
+    """Context add must be a dict."""
+    with pytest.raises(ContextError) as err:
+        add.run_step(Context({
+            'add': 1}))
+
+    assert str(err.value) == (
+        "context['add'] must exist, be iterable and contain 'set' for "
+        "pypyr.steps.add. argument of type 'int' is not iterable")
+
+
+def test_add_no_base_object():
+    """Set input must exist."""
+    with pytest.raises(KeyNotInContextError) as err:
+        add.run_step(Context({
+            'add': {}}))
+
+    assert str(err.value) == (
+        "context['add']['set'] doesn't exist. It must exist for "
+        "pypyr.steps.add.")
+
+
+def test_add_no_add_me():
+    """Input add_me must exist."""
+    with pytest.raises(KeyNotInContextError):
+        add.run_step(Context({
+            'add': {
+                'set': 'arbset'
+            }}))
+
+
+def test_add_with_empty_base():
+    """Input list is empty."""
+    with pytest.raises(KeyInContextHasNoValueError):
+        add.run_step(Context({
+            'add': {
+                'set': '',
+                'addMe': ''}}))
+
+
+def test_add_with_none_base():
+    """Input set is empty."""
+    with pytest.raises(KeyInContextHasNoValueError):
+        add.run_step(Context({
+            'add': {
+                'set': None,
+                'addMe': None}}))
+
+
+# endregion validation
+
+def test_add_with_none_add():
+    """Add None to set."""
+    context = Context({
+        'add': {
+            'set': 'arbset',
+            'addMe': None
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 'one'
+
+    add.run_step(context)
+
+    assert context['arbset'] == {None, 'one'}
+    assert len(context) == 2
+
+
+def test_add_pass_with_minimal_create():
+    """Create set with minimal parameters success."""
+    context = Context({
+        'add': {
+            'set': 'arbset',
+            'addMe': 1
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 2
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2}
+    assert len(context) == 2
+
+
+def test_add_fail_with_create_from_list_unpack_implicit():
+    """When addMe not hashable fail unless is list - unpack implicit True."""
+    context = Context({
+        'add': {
+            'set': 'arbset',
+            'addMe': [1, 2]
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = [3, 4]
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4}
+    assert len(context) == 2
+
+
+def test_add_fail_with_create_from_list_unpack_false():
+    """When addMe not hashable fail unless is list - unpack explicit False."""
+    context = Context({
+        'add': {
+            'set': 'arbset',
+            'addMe': [1, 2],
+            'unpack': False
+        }})
+
+    with pytest.raises(TypeError):
+        add.run_step(context)
+
+
+def test_add_pass_with_create_from_list_extend():
+    """Create new set with extend."""
+    context = Context({
+        'add': {
+            'set': 'arbset',
+            'addMe': [1, 2],
+            'unpack': True
+        }})
+
+    add.run_step(context)
+
+    context['add']['unpack'] = False
+    context['add']['addMe'] = 3
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3}
+    assert len(context) == 2
+
+
+def test_add_pass_with_create_from_list_and_add():
+    """Add lists with unpack explicitly true."""
+    context = Context({
+        'add': {
+            'set': 'arbset',
+            'addMe': [1, 2],
+            'unpack': True
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = [3, 4]
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4}
+    assert len(context) == 2
+
+
+def test_add_pass_existing():
+    """Add to existing set."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': 'arbset',
+            'addMe': 3
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 4
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4}
+    assert len(context) == 2
+
+
+def test_add_pass_with_extend_existing():
+    """Extend existing set."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': 'arbset',
+            'addMe': [3, 4],
+            'unpack': True
+        }})
+
+    add.run_step(context)
+
+    context['add']['unpack'] = False
+    context['add']['addMe'] = 5
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4, 5}
+    assert len(context) == 2
+
+
+def test_add_with_set_input():
+    """Input is a set, not a string key."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': 3
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 4
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4}
+    assert len(context) == 2
+
+
+def test_add_with_set_input_extend():
+    """Input is a set, not a string key with an extend."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': 3
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = [4, 5]
+    context['add']['unpack'] = True
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4, 5}
+    assert len(context) == 2
+
+
+def test_add_with_formatting():
+    """Use formatting expressions."""
+    context = Context({
+        'arbset': {1, 2},
+        'addthis': 3,
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': '{addthis}'
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 4
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4}
+    assert len(context) == 3
+
+
+def test_add_set_with_formatting_tuple():
+    """Use formatting expressions to add tuple."""
+    context = Context({
+        'arbset': {1, 2},
+        'addthis': (3, 4),
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': '{addthis}',
+            'unpack': True
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 5
+    context['add']['unpack'] = False
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4, 5}
+    assert len(context) == 3
+
+
+def test_add_with_formatting_extend():
+    """Use formatting expressions."""
+    context = Context({
+        'arbset': {1, 2},
+        'addthis': [3, 4],
+        'extend_me': True,
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': '{addthis}',
+            'unpack': '{extend_me}'
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = [5, 6]
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 3, 4, 5, 6}
+    assert len(context) == 4
+
+
+def test_add_with_single_string():
+    """Add single string."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': 'three'
+        }})
+
+    add.run_step(context)
+
+    context['add']['addMe'] = 'four'
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 'three', 'four'}
+    assert len(context) == 2
+
+
+def test_add_with_strings():
+    """Add multiple strings."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': ('three', 'four'),
+            'unpack': True
+        }})
+
+    add.run_step(context)
+
+    context['add']['unpack'] = False
+    context['add']['addMe'] = 'five'
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 'three', 'four', 'five'}
+    assert len(context) == 2
+
+
+def test_add_with_strings_update():
+    """Add strings with update."""
+    context = Context({
+        'arbset': {1, 2},
+        'add': {
+            'set': PyString('arbset'),
+            'addMe': 'xy',
+            'unpack': True
+        }})
+
+    add.run_step(context)
+
+    context['add']['unpack'] = False
+    context['add']['addMe'] = 'z'
+
+    add.run_step(context)
+
+    assert context['arbset'] == {1, 2, 'x', 'y', 'z'}
+    assert len(context) == 2

--- a/tests/unit/pypyr/steps/append_test.py
+++ b/tests/unit/pypyr/steps/append_test.py
@@ -1,0 +1,321 @@
+"""append.py unit tests."""
+import pytest
+
+from pypyr.context import Context
+from pypyr.dsl import PyString
+from pypyr.errors import (ContextError,
+                          KeyInContextHasNoValueError,
+                          KeyNotInContextError)
+from pypyr.steps import append
+
+
+# region validation
+def test_append_no_input():
+    """Context append must exist."""
+    with pytest.raises(KeyNotInContextError):
+        append.run_step(Context())
+
+
+def test_append_not_a_dict():
+    """Context append must be a dict."""
+    with pytest.raises(ContextError) as err:
+        append.run_step(Context({
+            'append': 1}))
+
+    assert str(err.value) == (
+        "context['append'] must exist, be iterable and contain 'list' for "
+        "pypyr.steps.append. argument of type 'int' is not iterable")
+
+
+def test_append_no_base_object():
+    """List input must exist."""
+    with pytest.raises(KeyNotInContextError) as err:
+        append.run_step(Context({
+            'append': {}}))
+
+    assert str(err.value) == (
+        "context['append']['list'] doesn't exist. It must exist for "
+        "pypyr.steps.append.")
+
+
+def test_append_no_add_me():
+    """Input add_me must exist."""
+    with pytest.raises(KeyNotInContextError):
+        append.run_step(Context({
+            'append': {
+                'list': 'arblist'
+            }}))
+
+
+def test_append_with_empty_base():
+    """Input list is empty."""
+    with pytest.raises(KeyInContextHasNoValueError):
+        append.run_step(Context({
+            'append': {
+                        'list': '',
+                        'addMe': ''}}))
+
+
+def test_append_with_none_base():
+    """Input list is empty."""
+    with pytest.raises(KeyInContextHasNoValueError):
+        append.run_step(Context({
+            'append': {
+                        'list': None,
+                        'addMe': None}}))
+
+
+# endregion validation
+
+def test_append_with_none_add():
+    """Add None to list."""
+    context = Context({
+        'append': {
+            'list': 'arblist',
+            'addMe': None
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 'one'
+
+    append.run_step(context)
+
+    assert context['arblist'] == [None, 'one']
+    assert len(context) == 2
+
+
+def test_append_pass_with_minimal_create():
+    """Create list with minimal parameters success."""
+    context = Context({
+        'append': {
+            'list': 'arblist',
+            'addMe': 1
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 2
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2]
+    assert len(context) == 2
+
+
+def test_append_pass_with_create_from_list_no_extend():
+    """Minimal paramaters success."""
+    context = Context({
+        'append': {
+            'list': 'arblist',
+            'addMe': [1, 2]
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 3
+
+    append.run_step(context)
+
+    assert context['arblist'] == [[1, 2], 3]
+    assert len(context) == 2
+
+
+def test_append_pass_with_create_from_list_extend():
+    """Create new list with extend."""
+    context = Context({
+        'append': {
+            'list': 'arblist',
+            'addMe': [1, 2],
+            'unpack': True
+        }})
+
+    append.run_step(context)
+
+    context['append']['unpack'] = False
+    context['append']['addMe'] = 3
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3]
+    assert len(context) == 2
+
+
+def test_append_pass_existing():
+    """Append existing list."""
+    context = Context({
+        'arblist': [1, 2],
+        'append': {
+            'list': 'arblist',
+            'addMe': 3
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 4
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3, 4]
+    assert len(context) == 2
+
+
+def test_append_pass_with_extend_existing():
+    """Extend existing list."""
+    context = Context({
+        'arblist': [1, 2],
+        'append': {
+            'list': 'arblist',
+            'addMe': [3, 4],
+            'unpack': True
+        }})
+
+    append.run_step(context)
+
+    context['append']['unpack'] = False
+    context['append']['addMe'] = 5
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3, 4, 5]
+    assert len(context) == 2
+
+
+def test_append_with_list_input():
+    """Input is a list, not a string key."""
+    context = Context({
+        'arblist': [1, 2],
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': 3
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 4
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3, 4]
+    assert len(context) == 2
+
+
+def test_append_with_list_input_extend():
+    """Input is a list, not a string key with an extend."""
+    context = Context({
+        'arblist': [1, 2],
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': 3
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = [4, 5]
+    context['append']['unpack'] = True
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3, 4, 5]
+    assert len(context) == 2
+
+
+def test_append_with_formatting():
+    """Use formatting expressions."""
+    context = Context({
+        'arblist': [1, 2],
+        'addthis': 3,
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': '{addthis}'
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 4
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3, 4]
+    assert len(context) == 3
+
+
+def test_append_list_with_formatting_no_extend():
+    """Use formatting expressions to append list without extend."""
+    context = Context({
+        'arblist': [1, 2],
+        'addthis': [3, 4],
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': '{addthis}'
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 5
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, [3, 4], 5]
+    assert len(context) == 3
+
+
+def test_append_with_formatting_extend():
+    """Use formatting expressions."""
+    context = Context({
+        'arblist': [1, 2],
+        'addthis': [3, 4],
+        'extend_me': True,
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': '{addthis}',
+            'unpack': '{extend_me}'
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = [5, 6]
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 3, 4, 5, 6]
+    assert len(context) == 4
+
+
+def test_append_with_strings():
+    """Append strings."""
+    context = Context({
+        'arblist': [1, 2],
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': 'three'
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 'four'
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 'three', 'four']
+    assert len(context) == 2
+
+
+def test_append_with_strings_unpack():
+    """Append strings with unpack."""
+    context = Context({
+        'arblist': [1, 2],
+        'append': {
+            'list': PyString('arblist'),
+            'addMe': 'xy',
+            'unpack': True
+        }})
+
+    append.run_step(context)
+
+    context['append']['addMe'] = 'z'
+
+    append.run_step(context)
+
+    assert context['arblist'] == [1, 2, 'x', 'y', 'z']
+    assert len(context) == 2

--- a/tests/unit/pypyr/utils/asserts_test.py
+++ b/tests/unit/pypyr/utils/asserts_test.py
@@ -155,3 +155,96 @@ def test_assert_key_has_value_object_none_no_parent():
         "context['k1'] must exist and be iterable for arb caller. argument of "
         "type 'NoneType' is not iterable")
 # endregion assert_key_has_value
+
+# region assert_key_is_truthy
+
+
+def test_assert_key_is_truthy_passes():
+    """Success case."""
+    asserts.assert_key_is_truthy(obj={'k1': 'v1'},
+                                 key='k1',
+                                 caller='arb caller',
+                                 parent='parent name')
+
+
+def test_assert_key_is_truthy_value_empty():
+    """Is a truthy."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        asserts.assert_key_is_truthy(obj={'k1': ''},
+                                     key='k1',
+                                     caller='arb caller',
+                                     parent='parent name')
+
+    assert str(err.value) == ("context['parent name']['k1'] must have a value "
+                              "for arb caller.")
+
+
+def test_assert_key_is_truthy_none():
+    """Key value is none."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        asserts.assert_key_is_truthy(obj={'k1': None},
+                                     key='k1',
+                                     caller='arb caller',
+                                     parent='parent name')
+
+    assert str(err.value) == ("context['parent name']['k1'] must have a value "
+                              "for arb caller.")
+
+
+def test_assert_key_is_truthy_none_no_parent():
+    """Key value is none and no parent."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        asserts.assert_key_is_truthy(obj={'k1': None},
+                                     key='k1',
+                                     caller='arb caller')
+
+    assert str(err.value) == "context['k1'] must have a value for arb caller."
+
+
+def test_assert_key_is_truthy_key_not_there():
+    """Key not in object."""
+    with pytest.raises(KeyNotInContextError) as err:
+        asserts.assert_key_is_truthy(obj={'k1': None},
+                                     key='k2',
+                                     caller='arb caller',
+                                     parent='parent name')
+
+    assert str(err.value) == ("context['parent name']['k2'] doesn't exist. "
+                              "It must exist for arb caller.")
+
+
+def test_assert_key_is_truthy_key_not_there_no_parent():
+    """Key not in object and no parent."""
+    with pytest.raises(KeyNotInContextError) as err:
+        asserts.assert_key_is_truthy(obj={'k1': None},
+                                     key='k2',
+                                     caller='arb caller')
+
+    assert str(err.value) == ("context['k2'] doesn't exist. "
+                              "It must exist for arb caller.")
+
+
+def test_assert_key_is_truthy_object_none():
+    """Object is None should raise."""
+    with pytest.raises(ContextError) as err:
+        asserts.assert_key_is_truthy(obj=None,
+                                     key='k1',
+                                     caller='arb caller',
+                                     parent='parent name')
+
+    assert str(err.value) == (
+        "context['parent name'] must exist, be iterable and contain 'k1' for "
+        "arb caller. argument of type 'NoneType' is not iterable")
+
+
+def test_assert_key_is_truthy_object_none_no_parent():
+    """Object is None should raise with no parent."""
+    with pytest.raises(ContextError) as err:
+        asserts.assert_key_is_truthy(obj=None,
+                                     key='k1',
+                                     caller='arb caller')
+
+    assert str(err.value) == (
+        "context['k1'] must exist and be iterable for arb caller. argument of "
+        "type 'NoneType' is not iterable")
+# endregion assert_key_is_truthy


### PR DESCRIPTION
Close #121.

New steps for handling lists & sets:
- pypyr.steps.append
  - append or extend items to a list
- pypyr.steps.add
  - add or update a set
- New validation/assert helper for truthy checks on context input. 