### PR TITLE
pypyr.steps.fileread

### DIFF
--- a/pypyr/steps/fileread.py
+++ b/pypyr/steps/fileread.py
@@ -1,0 +1,61 @@
+"""pypyr step that reads a file into context."""
+import logging
+from pypyr.utils.asserts import assert_keys_are_truthy
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Load a file into context.
+
+    Open file at path as text using locale.getpreferredencoding().
+    Open file at path as binary bytes if binary=True.
+
+    Save file payload to key in context.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context key must exist
+                - fileRead
+                    - path. path-like. Path to file on disk.
+                    - key. string. Write file payload to this context key.
+                    - binary. boolean. Default False. Set to True to read file
+                      content as bytes in binary mode.
+
+    All inputs support formatting expressions.
+
+    Returns:
+        None. mutates context arg.
+
+    Raises:
+        FileNotFoundError: take a guess
+        pypyr.errors.KeyNotInContextError: fileRead.path or fileRead.key
+                                           missing in context.
+        pypyr.errors.KeyInContextHasNoValueError: fileRead.path or fileRead.key
+                                                  exists but is empty.
+
+    """
+    logger.debug("started")
+
+    context.assert_key_has_value(key='fileRead', caller=__name__)
+
+    file_read = context.get_formatted('fileRead')
+
+    assert_keys_are_truthy(obj=file_read,
+                           keys=('path', 'key'),
+                           caller=__name__,
+                           parent='fileRead')
+
+    file_path = file_read['path']
+    destination_key = file_read['key']
+    mode = 'rb' if file_read.get('binary', False) is True else 'r'
+
+    logger.debug("attempting to open file with mode '%s': %s", mode, file_path)
+
+    with open(file_path, mode) as file:
+        payload = file.read()
+
+    context[destination_key] = payload
+
+    logger.info("file read into pypyr context at key: %s", destination_key)
+    logger.debug("done")

--- a/pypyr/utils/asserts.py
+++ b/pypyr/utils/asserts.py
@@ -104,3 +104,29 @@ def assert_key_is_truthy(obj, key, caller, parent=None):
             msg = f"context[{key!r}] must have a value for {caller}."
 
         raise KeyInContextHasNoValueError(msg)
+
+
+def assert_keys_are_truthy(obj, keys, caller, parent=None):
+    """Assert keys exists in obj and evaluates truthy.
+
+    Empty string or 0 does NOT count as a value.
+
+    Error messages are structured as if obj is a pypyr Context.
+
+    Keys is an iterable of key names to check.
+
+    Args:
+        obj (mapping): object to check for key.
+        keys (list[hashable]): iterable of keys to check in obj
+        caller (string): calling function name - this used to construct
+                         error messages. Tip: use .__name__
+        parent (string): parent key name. Used to construct error messages to
+                         indicate the name of obj in context.
+
+    Raises:
+        ContextError: if obj is None or not iterable.
+        KeyInContextHasNoValueError: if not bool(context[key])
+        KeyNotInContextError: Key doesn't exist
+    """
+    for key in keys:
+        assert_key_is_truthy(obj, key, caller, parent)

--- a/tests/unit/pypyr/steps/fileread_test.py
+++ b/tests/unit/pypyr/steps/fileread_test.py
@@ -1,0 +1,195 @@
+"""fileread.py unit tests."""
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from pypyr.context import Context
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
+import pypyr.steps.fileread as fileread
+
+
+def test_fileread_no_input_raises():
+    """No input."""
+    context = Context({
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileread.")
+
+
+def test_fileread_none_raises():
+    """Input exists but is None."""
+    context = Context({
+        'k1': 'v1',
+        'fileRead': None})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead'] must have a "
+                                   "value for pypyr.steps.fileread.")
+
+
+def test_fileread_none_path_raises():
+    """None path raises."""
+    context = Context({
+        'fileRead': {
+            'path': None}})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead']['path'] must have a "
+                                   "value for pypyr.steps.fileread.")
+
+
+def test_fileread_empty_path_raises():
+    """Empty path raises."""
+    context = Context({
+        'fileRead': {
+            'path': ''}})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead']['path'] must have a "
+                                   "value for pypyr.steps.fileread.")
+
+
+def test_fileread_no_key_raises():
+    """No key raises."""
+    context = Context({
+        'fileRead': {
+            'path': '/arb'}})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead']['key'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fileread.")
+
+
+def test_fileread_none_key_raises():
+    """None key raises."""
+    context = Context({
+        'fileRead': {
+            'path': '/arb',
+            'key': None}})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead']['key'] must have a "
+                                   "value for pypyr.steps.fileread.")
+
+
+def test_fileread_empty_key_raises():
+    """Empty key raises."""
+    context = Context({
+        'fileRead': {
+            'path': '/arb',
+            'key': ''}})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        fileread.run_step(context)
+
+    assert str(err_info.value) == ("context['fileRead']['key'] must have a "
+                                   "value for pypyr.steps.fileread.")
+
+# endregion validation
+
+# region text mode
+
+
+def test_fileread_defaults():
+    """Read file with minimal defaults."""
+    context = Context({
+        'fileRead': {
+            'path': '/arb',
+            'key': 'out'}})
+
+    with patch('pypyr.steps.fileread.open',
+               mock_open(read_data='one\ntwo\nthree')) as mocked_open:
+        fileread.run_step(context)
+
+    assert context['out'] == 'one\ntwo\nthree'
+
+    mocked_open.assert_called_once_with('/arb', 'r')
+# endregion text mode
+
+# region binary mode
+
+
+def test_fileread_binary_true():
+    """Read file with binary true."""
+    context = Context({
+        'fileRead': {
+            'path': '/arb',
+            'key': 'out',
+            'binary': True}})
+
+    with patch('pypyr.steps.fileread.open',
+               mock_open(read_data=b'12345')) as mocked_open:
+        fileread.run_step(context)
+
+    assert context['out'] == b'12345'
+
+    mocked_open.assert_called_once_with('/arb', 'rb')
+
+
+def test_fileread_binary_explicit_false():
+    """Read file with binary explicit false."""
+    context = Context({
+        'fileRead': {
+            'path': '/arb',
+            'key': 'out',
+            'binary': False}})
+
+    with patch('pypyr.steps.fileread.open',
+               mock_open(read_data='one\ntwo\nthree')) as mocked_open:
+        fileread.run_step(context)
+
+    assert context['out'] == 'one\ntwo\nthree'
+
+    mocked_open.assert_called_once_with('/arb', 'r')
+
+# endregion binary mode
+
+# region substitutions
+
+
+def test_fileread_substitutions():
+    """Read file with substitutions."""
+    context = Context({
+        'p': '/arb',
+        'k': 'out',
+        'b': False,
+        'fileRead': {
+            'path': '{p}',
+            'key': '{k}',
+            'binary': '{b}'}})
+
+    with patch('pypyr.steps.fileread.open',
+               mock_open(read_data='one\ntwo\nthree')) as mocked_open:
+        fileread.run_step(context)
+
+    assert context['out'] == 'one\ntwo\nthree'
+
+    assert context == {
+        'p': '/arb',
+        'k': 'out',
+        'b': False,
+        'out': 'one\ntwo\nthree',
+        'fileRead': {
+            'path': '{p}',
+            'key': '{k}',
+            'binary': '{b}'}}
+
+    mocked_open.assert_called_once_with('/arb', 'r')
+
+# endregion substitutions

--- a/tests/unit/pypyr/utils/asserts_test.py
+++ b/tests/unit/pypyr/utils/asserts_test.py
@@ -248,3 +248,42 @@ def test_assert_key_is_truthy_object_none_no_parent():
         "context['k1'] must exist and be iterable for arb caller. argument of "
         "type 'NoneType' is not iterable")
 # endregion assert_key_is_truthy
+
+# region assert_keys_are_truthy
+
+
+def test_assert_keys_are_truthy():
+    """Multiple keys on truthy check."""
+    asserts.assert_keys_are_truthy(obj={'k1': 'v1', 'k2': 'v2', 'k3': 'v3'},
+                                   keys=('k1', 'k3'),
+                                   caller='arb caller',
+                                   parent='parent name')
+
+
+def test_assert_keys_are_truthy_none():
+    """Key value is none for one of the keys raise error."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        asserts.assert_keys_are_truthy(obj={'k1': 'v1',
+                                            'k2': None,
+                                            'k3': 'v3'},
+                                       keys=['k1', 'k3', 'k2'],
+                                       caller='arb caller',
+                                       parent='parent name')
+
+    assert str(err.value) == ("context['parent name']['k2'] must have a value "
+                              "for arb caller.")
+
+
+def test_assert_keys_are_truthy_empty():
+    """Key value is empty for one of the keys raise error."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        asserts.assert_keys_are_truthy(obj={'k1': 'v1',
+                                            'k2': '',
+                                            'k3': 'v3'},
+                                       keys=['k1', 'k3', 'k2'],
+                                       caller='arb caller',
+                                       parent='parent name')
+
+    assert str(err.value) == ("context['parent name']['k2'] must have a value "
+                              "for arb caller.")
+# endregion assert_keys_are_truthy


### PR DESCRIPTION
- add `pypyr.steps.fileread` to read files in text or binary mode into context.
- add `assert_keys_are_truthy` validator - this allows steps to use only 1 line to check for multiple child-keys on a step input.
