### PR TITLE
pypyr.steps.filewrite

### DIFF
--- a/pypyr/steps/fileread.py
+++ b/pypyr/steps/fileread.py
@@ -48,7 +48,7 @@ def run_step(context):
 
     file_path = file_read['path']
     destination_key = file_read['key']
-    mode = 'rb' if file_read.get('binary', False) is True else 'r'
+    mode = 'rb' if file_read.get('binary', False) else 'r'
 
     logger.debug("attempting to open file with mode '%s': %s", mode, file_path)
 

--- a/pypyr/steps/filewrite.py
+++ b/pypyr/steps/filewrite.py
@@ -1,0 +1,66 @@
+"""pypyr step that writes payload out to a file."""
+import logging
+from pathlib import Path
+
+from pypyr.utils.asserts import assert_key_is_truthy
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Write payload to file.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context keys expected:
+                - fileWrite
+                    - path. mandatory. path-like. Write output file to
+                      here. Will create directories in path for you.
+                    - payload. optional. Write this value to output file.
+                    - append. boolean. Default False. Set to True to append to
+                      file if it exists already. If False will overwrite
+                      existing file.
+                    - binary. boolean. Default False. Set to True to write file
+                      content as bytes in binary mode. Set both append & binary
+                      True to append to binary file.
+
+    Returns:
+        None.
+
+    Raises:
+        pypyr.errors.KeyNotInContextError: fileWrite or
+            fileWrite['path'] missing in context.
+        pypyr.errors.KeyInContextHasNoValueError: fileWrite or
+            fileWrite['path'] exists but is None/Empty.
+
+    """
+    logger.debug("started")
+    context.assert_key_has_value('fileWrite', __name__)
+
+    file_write = context.get_formatted('fileWrite')
+    assert_key_is_truthy(obj=file_write,
+                         key='path',
+                         caller=__name__,
+                         parent='fileWrite')
+
+    path = Path(file_write['path'])
+    is_append = file_write.get('append', False)
+    is_binary = file_write.get('binary', False)
+
+    if is_binary:
+        mode = 'ab' if is_append else 'wb'
+        payload = file_write['payload']
+    else:
+        mode = 'a' if is_append else 'w'
+        # if payload is str already, str(payload) is payload (same obj id)
+        payload = str(file_write['payload'])
+
+    logger.debug("opening destination file for writing: %s", path)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, mode) as file:
+        file.write(payload)
+
+    logger.info("formatted context & wrote to %s", path)
+    logger.debug("done")

--- a/pypyr/steps/filewritejson.py
+++ b/pypyr/steps/filewritejson.py
@@ -1,9 +1,10 @@
 """pypyr step that writes payload out to a json file."""
 import json
 import logging
-import os
+from pathlib import Path
+
 from pypyr.utils.asserts import assert_key_has_value
-# logger means the log level will be set correctly
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,14 +39,16 @@ def run_step(context):
                          caller=__name__,
                          parent='fileWriteJson')
 
-    out_path = input_context['path']
+    out_path = Path(input_context['path'])
     # doing it like this to safeguard against accidentally dumping all context
     # with potentially sensitive values in it to disk if payload exists but is
     # None.
     is_payload_specified = 'payload' in input_context
 
     logger.debug("opening destination file for writing: %s", out_path)
-    os.makedirs(os.path.abspath(os.path.dirname(out_path)), exist_ok=True)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
     with open(out_path, 'w') as outfile:
         if is_payload_specified:
             payload = input_context['payload']

--- a/pypyr/steps/filewriteyaml.py
+++ b/pypyr/steps/filewriteyaml.py
@@ -1,6 +1,7 @@
 """pypyr step that writes payload out to a yaml file."""
-import os
 import logging
+from pathlib import Path
+
 from pypyr.utils.asserts import assert_key_has_value
 import pypyr.yaml
 
@@ -38,7 +39,7 @@ def run_step(context):
                          key='path',
                          caller=__name__,
                          parent='fileWriteYaml')
-    out_path = input_context['path']
+    out_path = Path(input_context['path'])
     # doing it like this to safeguard against accidentally dumping all context
     # with potentially sensitive values in it to disk if payload exists but is
     # None.
@@ -47,7 +48,9 @@ def run_step(context):
     yaml_writer = pypyr.yaml.get_yaml_parser_roundtrip_for_context()
 
     logger.debug("opening destination file for writing: %s", out_path)
-    os.makedirs(os.path.abspath(os.path.dirname(out_path)), exist_ok=True)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
     with open(out_path, 'w') as outfile:
         if is_payload_specified:
             payload = input_context['payload']

--- a/tests/unit/pypyr/steps/filewrite_test.py
+++ b/tests/unit/pypyr/steps/filewrite_test.py
@@ -1,0 +1,577 @@
+"""fileWrite.py unit tests."""
+import io
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from pypyr.context import Context
+from pypyr.errors import (
+    ContextError,
+    KeyInContextHasNoValueError,
+    KeyNotInContextError)
+import pypyr.steps.filewrite as filewrite
+
+# region validation
+
+
+def test_filewrite_no_input_raises():
+    """No input fileWrite raises."""
+    context = Context({
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWrite'] doesn't exist. "
+        "It must exist for pypyr.steps.filewrite.")
+
+
+def test_filewrite_none_filewrite_raises():
+    """None fileWrite raises."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': None})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWrite'] must have a value for "
+        "pypyr.steps.filewrite.")
+
+
+def test_filewrite_filewrite_not_iterable_raises():
+    """Not iterable fileWrite raises."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': 1})
+
+    with pytest.raises(ContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWrite'] must exist, be iterable "
+        "and contain 'path' for pypyr.steps.filewrite. argument of type "
+        "'int' is not iterable")
+
+
+def test_filewrite_empty_path_raises():
+    """Empty path raises."""
+    context = Context({
+        'fileWrite': {
+            'path': ''
+        }})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWrite']['path'] must have a value for "
+        "pypyr.steps.filewrite.")
+
+
+def test_filewrite_none_path_raises():
+    """Empty path raises."""
+    context = Context({
+        'fileWrite': {
+            'path': None
+        }})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWrite']['path'] must have a value for "
+        "pypyr.steps.filewrite.")
+
+
+def test_filewrite_no_path_raises():
+    """No path raises."""
+    context = Context({
+        'fileWrite': 'blah',
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == ("context['fileWrite']['path'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.filewrite.")
+
+
+# endregion validation
+
+# region write text
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_payload(mock_path):
+    """Success case writes only specific context payload."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': "one\ntwo\nthree"
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 2, "context should have 2 items"
+    assert context['k1'] == 'v1'
+    assert context['fileWrite'] == {'path': '/arb/blah',
+                                    'payload': "one\ntwo\nthree"}
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == 'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_non_string_payload(mock_path):
+    """Empty payload write non string types to file."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': 123
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == '123'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_empty_payload(mock_path):
+    """Empty payload write empty file."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': ''
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == ''
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_none_payload(mock_path):
+    """None payload write empty file."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': None
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == 'None'
+
+# endregion write text
+# region append
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_append(mock_path):
+    """Append to file."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': "one\ntwo\nthree",
+            'append': True,
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'a')
+
+    assert payload == 'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_append_false(mock_path):
+    """Open in write mode when append explicitly False."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': "one\ntwo\nthree",
+            'append': False,
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == 'one\ntwo\nthree'
+
+# endregion append
+
+# region binary
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_binary(mock_path):
+    """Write binary data."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': b"one\ntwo\nthree",
+            'binary': True,
+        }})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        payload = out_bytes.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'wb')
+
+    assert payload == b'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_binary_false(mock_path):
+    """Open in write mode when binary explicitly False."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': "one\ntwo\nthree",
+            'binary': False,
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == 'one\ntwo\nthree'
+
+# endregion binary
+
+# region binary + append
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_binary_append(mock_path):
+    """Append binary data."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': b"one\ntwo\nthree",
+            'binary': True,
+            'append': True
+        }})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        payload = out_bytes.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'ab')
+
+    assert payload == b'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_binary_true_append_false(mock_path):
+    """Write binary data with append explicit False."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': b"one\ntwo\nthree",
+            'binary': True,
+            'append': False
+        }})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        payload = out_bytes.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'wb')
+
+    assert payload == b'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_binary_false_append_true(mock_path):
+    """Open in append mode when binary explicitly False."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': "one\ntwo\nthree",
+            'binary': False,
+            'append': True
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'a')
+
+    assert payload == 'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_binary_false_append_false(mock_path):
+    """Open in write mode when binary & append explicitly False."""
+    context = Context({
+        'k1': 'v1',
+        'fileWrite': {
+            'path': '/arb/blah',
+            'payload': "one\ntwo\nthree",
+            'binary': False,
+            'append': False
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == 'one\ntwo\nthree'
+
+# endregion binary + append
+
+# region substitutions
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_substitutions(mock_path):
+    """Success case writes only specified context with substitutions."""
+    context = Context({
+        'k1': 'v1',
+        'p': '/arb/path',
+        'intkey': 3,
+        'is_bin': True,
+        'is_append': True,
+        'fileWrite': {
+            'path': '{p}',
+            'payload': 'begin {k1} {intkey} end',
+            'binary': '{is_bin}',
+            'append': '{is_append}'
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 6, "context should have 6 items"
+    assert context['k1'] == 'v1'
+    assert context['fileWrite'] == {
+        'path': '{p}',
+        'payload': 'begin {k1} {intkey} end',
+        'binary': '{is_bin}',
+        'append': '{is_append}'
+    }
+
+    mock_path.assert_called_once_with('/arb/path')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'ab')
+
+    assert payload == 'begin v1 3 end'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_substitutions_bare_payload(mock_path):
+    """Write bare formatting expression as payload."""
+    context = Context({
+        'k1': 'v1',
+        'p': '/arb/path',
+        'out': 'one\ntwo\nthree',
+        'is_append': False,
+        'fileWrite': {
+            'path': '{p}',
+            'payload': '{out}',
+            'append': '{is_append}'
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 5, "context should have 5 items"
+    assert context['k1'] == 'v1'
+    assert context['fileWrite'] == {
+        'path': '{p}',
+        'payload': '{out}',
+        'append': '{is_append}'
+    }
+
+    mock_path.assert_called_once_with('/arb/path')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == 'one\ntwo\nthree'
+
+
+@patch('pypyr.steps.filewrite.Path')
+def test_filewrite_pass_with_non_string_substitutions(mock_path):
+    """Convert non-string to str on text write with substitution."""
+    context = Context({
+        'k1': 'v1',
+        'p': '/arb/path',
+        'intkey': 123,
+        'is_bin': False,
+        'is_append': 0,
+        'fileWrite': {
+            'path': '{p}',
+            'payload': '{intkey}',
+            'binary': '{is_bin}',
+            'append': '{is_append}'
+        }})
+
+    with io.StringIO() as out_text:
+        with patch('pypyr.steps.filewrite.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_text.write
+            filewrite.run_step(context)
+
+        payload = out_text.getvalue()
+
+    mock_path.assert_called_once_with('/arb/path')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'w')
+
+    assert payload == '123'
+# endregion substitutions

--- a/tests/unit/pypyr/steps/filewritejson_test.py
+++ b/tests/unit/pypyr/steps/filewritejson_test.py
@@ -1,7 +1,9 @@
 """filewritejson.py unit tests."""
-import pytest
 import io
 from unittest.mock import mock_open, patch
+
+import pytest
+
 from pypyr.context import Context
 from pypyr.errors import (
     ContextError,
@@ -81,8 +83,8 @@ def test_filewritejson_no_path_raises():
                                    "pypyr.steps.filewritejson.")
 
 
-@patch('os.makedirs')
-def test_filewritejson_pass_no_payload(mock_makedirs):
+@patch('pypyr.steps.filewritejson.Path')
+def test_filewritejson_pass_no_payload(mock_path):
     """Success case writes all context out when no payload."""
     context = Context({
         'k1': 'v1',
@@ -101,8 +103,11 @@ def test_filewritejson_pass_no_payload(mock_makedirs):
         assert context['k1'] == 'v1'
         assert context['fileWriteJson'] == {'path': '/arb/blah'}
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
         # json well formed & new lines and indents are where they should be
         assert out_text.getvalue() == ('{\n'
                                        '  "k1": "v1",\n'
@@ -112,8 +117,8 @@ def test_filewritejson_pass_no_payload(mock_makedirs):
                                        '}')
 
 
-@patch('os.makedirs')
-def test_filewritejson_pass_with_payload(mock_makedirs):
+@patch('pypyr.steps.filewritejson.Path')
+def test_filewritejson_pass_with_payload(mock_path):
     """Success case writes only specific context payload."""
     context = Context({
         'k1': 'v1',
@@ -156,8 +161,12 @@ def test_filewritejson_pass_with_payload(mock_makedirs):
                                                 True
                                             ]}
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
+
         # json well formed & new lines + indents are where they should be
         assert out_text.getvalue() == ('[\n'
                                        '  "first",\n'
@@ -176,8 +185,8 @@ def test_filewritejson_pass_with_payload(mock_makedirs):
                                        ']')
 
 
-@patch('os.makedirs')
-def test_filewritejson_pass_no_payload_substitutions(mock_makedirs):
+@patch('pypyr.steps.filewritejson.Path')
+def test_filewritejson_pass_no_payload_substitutions(mock_path):
     """Success case writes all context out with substitutions."""
     context = Context({
         'k1': 'v1',
@@ -199,8 +208,11 @@ def test_filewritejson_pass_no_payload_substitutions(mock_makedirs):
         assert context['k1'] == 'v1'
         assert context['fileWriteJson'] == {'path': '{pathkey}'}
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/path', 'w')
+        mock_path.assert_called_once_with('/arb/path')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
         # json well formed & new lines + indents are where they should be
         assert out_text.getvalue() == ('{\n'
                                        '  "k1": "v1",\n'
@@ -219,8 +231,8 @@ def test_filewritejson_pass_no_payload_substitutions(mock_makedirs):
                                        '}')
 
 
-@patch('os.makedirs')
-def test_filewritejson_pass_with_payload_substitutions(mock_makedirs):
+@patch('pypyr.steps.filewritejson.Path')
+def test_filewritejson_pass_with_payload_substitutions(mock_path):
     """Success case writes only specified context with substitutions."""
     context = Context({
         'k1': 'v1',
@@ -258,8 +270,11 @@ def test_filewritejson_pass_with_payload_substitutions(mock_makedirs):
                                       }
                                      ]
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/path', 'w')
+        mock_path.assert_called_once_with('/arb/path')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
         # json well formed & new lines + indents are where they should be
         assert out_text.getvalue() == (
             '{\n'
@@ -275,8 +290,8 @@ def test_filewritejson_pass_with_payload_substitutions(mock_makedirs):
             '}')
 
 
-@patch('os.makedirs')
-def test_filewritejson_pass_with_empty_payload(mock_makedirs):
+@patch('pypyr.steps.filewritejson.Path')
+def test_filewritejson_pass_with_empty_payload(mock_path):
     """Empty payload write empty file."""
     context = Context({
         'k1': 'v1',
@@ -297,14 +312,18 @@ def test_filewritejson_pass_with_empty_payload(mock_makedirs):
         assert context['fileWriteJson']['path'] == '/arb/blah'
         assert context['fileWriteJson']['payload'] == ''
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
+
         # json well formed & new lines + indents are where they should be
         assert out_text.getvalue() == '""'
 
 
-@patch('os.makedirs')
-def test_filewritejson_pass_with_none_payload(mock_makedirs):
+@patch('pypyr.steps.filewritejson.Path')
+def test_filewritejson_pass_with_none_payload(mock_path):
     """None payload write empty file."""
     context = Context({
         'k1': 'v1',
@@ -325,7 +344,11 @@ def test_filewritejson_pass_with_none_payload(mock_makedirs):
         assert context['fileWriteJson']['path'] == '/arb/blah'
         assert context['fileWriteJson']['payload'] is None
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
+
         # json well formed & new lines + indents are where they should be
         assert out_text.getvalue() == "null"

--- a/tests/unit/pypyr/steps/filewriteyaml_test.py
+++ b/tests/unit/pypyr/steps/filewriteyaml_test.py
@@ -1,7 +1,9 @@
 """filewriteyaml.py unit tests."""
-import pytest
 import io
 from unittest.mock import mock_open, patch
+
+import pytest
+
 from pypyr.context import Context
 from pypyr.dsl import Jsonify
 from pypyr.errors import (
@@ -82,8 +84,8 @@ def test_filewriteyaml_no_path_raises():
                                    "pypyr.steps.filewriteyaml.")
 
 
-@patch('os.makedirs')
-def test_filewriteyaml_pass_no_payload(mock_makedirs):
+@patch('pypyr.steps.filewriteyaml.Path')
+def test_filewriteyaml_pass_no_payload(mock_path):
     """Success case writes all context out when no payload."""
     context = Context({
         'k1': 'v1',
@@ -102,16 +104,20 @@ def test_filewriteyaml_pass_no_payload(mock_makedirs):
         assert context['k1'] == 'v1'
         assert context['fileWriteYaml'] == {'path': '/arb/blah'}
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
+
         # yaml well formed & new lines and indents are where they should be
         assert out_text.getvalue() == ('k1: v1\n'
                                        'fileWriteYaml:\n'
                                        '  path: /arb/blah\n')
 
 
-@patch('os.makedirs')
-def test_filewriteyaml_pass_with_payload(mock_makedirs):
+@patch('pypyr.steps.filewriteyaml.Path')
+def test_filewriteyaml_pass_with_payload(mock_path):
     """Success case writes only specific context payload."""
     context = Context({
         'k1': 'v1',
@@ -154,8 +160,12 @@ def test_filewriteyaml_pass_with_payload(mock_makedirs):
                                                 True
                                             ]}
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
+
         # yaml well formed & new lines + indents are where they should be
         assert out_text.getvalue() == ('  - first\n'
                                        '  - second\n'
@@ -169,8 +179,8 @@ def test_filewriteyaml_pass_with_payload(mock_makedirs):
                                        '  - true\n')
 
 
-@patch('os.makedirs')
-def test_filewriteyaml_pass_no_payload_substitutions(mock_makedirs):
+@patch('pypyr.steps.filewriteyaml.Path')
+def test_filewriteyaml_pass_no_payload_substitutions(mock_path):
     """Success case writes all context out with substitutions."""
     context = Context({
         'k1': 'v1',
@@ -193,8 +203,12 @@ def test_filewriteyaml_pass_no_payload_substitutions(mock_makedirs):
         assert context['k1'] == 'v1'
         assert context['fileWriteYaml'] == {'path': '{pathkey}'}
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/path', 'w')
+        mock_path.assert_called_once_with('/arb/path')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
+
         # yaml well formed & new lines + indents are where they should be
         assert out_text.getvalue() == ('k1: v1\n'
                                        'pathkey: /arb/path\n'
@@ -208,8 +222,8 @@ def test_filewriteyaml_pass_no_payload_substitutions(mock_makedirs):
                                        '  path: /arb/path\n')
 
 
-@patch('os.makedirs')
-def test_filewriteyaml_pass_with_payload_substitutions(mock_makedirs):
+@patch('pypyr.steps.filewriteyaml.Path')
+def test_filewriteyaml_pass_with_payload_substitutions(mock_path):
     """Success case writes only specified context with substitutions."""
     context = Context({
         'k1': 'v1',
@@ -247,8 +261,11 @@ def test_filewriteyaml_pass_with_payload_substitutions(mock_makedirs):
                                       }
                                      ]
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/path', 'w')
+        mock_path.assert_called_once_with('/arb/path')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
         # yaml well formed & new lines + indents are where they should be
         assert out_text.getvalue() == ('child:\n'
                                        '  - v1\n'
@@ -258,8 +275,8 @@ def test_filewriteyaml_pass_with_payload_substitutions(mock_makedirs):
                                        '      - c\n')
 
 
-@patch('os.makedirs')
-def test_filewriteyaml_pass_with_empty_payload(mock_makedirs):
+@patch('pypyr.steps.filewriteyaml.Path')
+def test_filewriteyaml_pass_with_empty_payload(mock_path):
     """Empty payload write empty file."""
     context = Context({
         'k1': 'v1',
@@ -280,14 +297,17 @@ def test_filewriteyaml_pass_with_empty_payload(mock_makedirs):
         assert context['fileWriteYaml']['path'] == '/arb/blah'
         assert context['fileWriteYaml']['payload'] == ''
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
         # yaml well formed & new lines + indents are where they should be
         assert out_text.getvalue() == "''\n"
 
 
-@patch('os.makedirs')
-def test_filewriteyaml_pass_with_none_payload(mock_makedirs):
+@patch('pypyr.steps.filewriteyaml.Path')
+def test_filewriteyaml_pass_with_none_payload(mock_path):
     """None payload write empty file."""
     context = Context({
         'k1': 'v1',
@@ -308,7 +328,10 @@ def test_filewriteyaml_pass_with_none_payload(mock_makedirs):
         assert context['fileWriteYaml']['path'] == '/arb/blah'
         assert context['fileWriteYaml']['payload'] is None
 
-        mock_makedirs.assert_called_once_with('/arb', exist_ok=True)
-        mock_output.assert_called_once_with('/arb/blah', 'w')
+        mock_path.assert_called_once_with('/arb/blah')
+        mocked_path = mock_path.return_value
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                         exist_ok=True)
+        mock_output.assert_called_once_with(mocked_path, 'w')
         # yaml well formed & new lines + indents are where they should be
         assert out_text.getvalue() == "null\n...\n"


### PR DESCRIPTION
- add `pypyr.steps.filewrite` to write or append file in text or binary modes
- amend `filewriteyaml` to use `Path` rather than `os` - no functional change
- `pypyr.steps.fileread` binary check is truthy, rather than `is True`