### PR TITLE
toml

### DIFF
--- a/docs/adr/0003-toml-in-core.md
+++ b/docs/adr/0003-toml-in-core.md
@@ -1,0 +1,171 @@
+# Add TOML parsing to the core
+## Why do this?
+[TOML](https://toml.io/en/) is becoming a popular configuration format, and
+unavoidably so in Python in the shape of `pyproject.toml` as accepted by
+[PEP518](https://www.python.org/dev/peps/pep-0518/).
+
+One of pypyr's better features is wrangling configuration files between text,
+JSON and YAML for automation activities. Given TOML's recent rise in prominence,
+it makes sense to add functionality to pypyr for the usual read, write and
+formatting built-in steps.
+
+Under consideration is 
+1. Which TOML library to use
+2. Whether to add the TOML dependency to the pypyr core or as a separate plugin?
+
+## Which Python TOML Library is best?
+Since "best" is a variable term best left to click-bait internet articles,
+instead let's ask which TOML library more suits the current requirements of the
+project with the least negatives.
+
+### Selection criteria
+1. [TOML 1.0](https://github.com/toml-lang/toml/releases/tag/1.0.0) was released
+   on 2021/01/12. Most obvious criterion then is v1.0 compliance.
+2. Works with standard pypyr Context formatting operations. This means that
+   parsing output should use basic Python types, or is at least covariant with
+   the basic types - especially `Mapping` & `Sequence`. This is to make sure
+   that toml structures imports into Context and pipeline authors can use `set`
+   and formatting expressions like they would for any other Context item.
+3. Style (comments, whitespace) preserving round-trip parsing. This is nice to
+   have to allow pypyr to work with replacing values in a user's TOML file
+   without destroying the user's comments/whitespace.
+
+### Python TOML libraries at a glance
+- [tomli](https://github.com/hukkin/tomli)
+  - Relatively fast read-only parsing.
+- [tomlkit](https://github.com/sdispater/tomlkit) 
+  - Round-trip white-space/style preserving.
+- [toml](https://github.com/uiri/toml)
+  - This was initially vendored in pip itself to deal with `pyproject.toml`.
+  - Even so `pip` has since moved to `tomli`.
+- [pytoml](https://github.com/avakar/pytoml)
+  - Abandoned by the creator for eminently sensible reasons (interesting read
+    too... https://github.com/avakar/pytoml/issues/15) But let's not get into an
+    argument over whether a shiny new fashion in config formats is in fact doing
+    anything better than the previous fashions in config management.
+- [qtoml](https://github.com/alethiophile/qtoml)
+  - Still on TOML v0.5.0.
+
+Note these are the pure Python parsers - there are also a others using wrappers
+for different underlying tech:
+
+- [pytomlpp](https://github.com/bobfang1992/pytomlpp)
+  - Python wrapper for the [toml++](https://marzer.github.io/tomlplusplus/) C++
+    library.
+- [rtoml](https://github.com/samuelcolvin/rtoml)
+  - Python wrapper for fast parsing written in Rust.
+
+#### TOMLKit
+Of the available options, _only_ `tomlkit` supports style-preserving roundtrip
+parsing. Furthermore, `tomlkit` was created for the express purpose of handling
+TOML parsing for the [poetry](https://python-poetry.org) tool - as this is one
+of the 2 most popular new PEP517 & PEP518 Python build systems there is some
+comfort in the wide adoption of a very actively used tool that means a greater
+likelihood of maintenance & support, and specifically that `pyproject.toml`
+files _should_ parse without surprises.
+
+TOMLKit only lists itself as `1.0.0rc1` compliant. Looking at the [TOML spec
+release history](https://github.com/toml-lang/toml/releases/) delta of `rc1` vs
+`v1`, it only looks like clarifications & administrative/documentation updates -
+there doesn't _seem_ to be anything notable missing or functionally different in
+`rc1` as opposed to `v1`. It's not impossible that I missed something, though -
+but given `TOMLKit`'s wide usage via `poetry`, I would expect obvious
+out-of-date spec handling to have been noticed by someone somewhere, and I see
+none such in the [issues list](https://github.com/sdispater/tomlkit/issues).
+
+There is a but... `TOMLKit` fails the third requirement - it is not
+interoperable with the pypyr Context because it outputs custom types rather than
+Python built-ins. Specifically it represents tables with classes like
+`class Table(Item,MutableMapping, dict)` or
+`class InlineTable(Item, MutableMapping, dict)`. 
+
+(See here for [TOMLkit API types](https://github.com/sdispater/tomlkit/blob/master/tomlkit/items.py).)
+
+The constructors for these do NOT allow any of these to instantiate like a
+standard `Mapping` type does - which means that the pypyr Context formatting &
+merge methods cannot work with structures loaded from TOML _unless_ we add
+specific type handling for these. As a matter of principle, I am not cheerful
+about having Context be more type aware than the basic type system and
+`collections.abc` - `pypyr.context.Context` is a dependency for a lot of other
+pypyr modules, but also, where does it end? Instead, if anything, Context would
+need re-coding to create shallow copies + in-place update of the copy instead of
+using the ctor to instantiate a new container for formatting output. This is not
+a trivial change and has the potential to break fundamental functionality for
+pretty much everyone.
+
+That the TOML parser output interoperates with the pypyr Context is a more
+important requirement than that it is style-preserving. Pipeline authors can of
+course maintain style/whitespace while formatting TOML files by using either
+`pypyr.steps.filereplace` and `pypyr.steps.fileformat` (the former in all cases,
+the latter if the TOML contains no {} structural braces for inline tables).
+Therefore, having a style preserving TOML parser is not essential in that pypyr
+can already serve the functionality elsewhere.
+
+#### toml
+The `toml` library is a largely historical artifact at this point. Not only is
+it well behind on implementing TOML v1, but also because of lack of maintenance
+on functionality as is - even `pip` itself [has moved from vendoring `toml` to
+`tomli`](https://github.com/pypa/pip/pull/10035). This exodus from `toml` to
+`tomli` includes the very prominent:
+- [pip](https://github.com/pypa/pip/issues/10034)
+- [typeshed](https://github.com/python/typeshed/issues/6022)
+- [black](https://github.com/psf/black/issues/2280)
+- [mypy](https://github.com/python/mypy/pull/10824)
+- [coverage](https://github.com/nedbat/coveragepy/issues/1180)
+- [flit](https://github.com/pypa/flit/pull/438)
+
+#### tomli
+`tomli` then seems to be where the Python community in general is coalescing for
+a standard TOML parser. `tomli` is read-only, for write functionality there is
+the companion library [tomli-w](https://github.com/hukkin/tomli-w).
+
+`tomli` is explicitly TOML v1.0 compliant.
+
+`tomli` is _significantly_ faster than TOMLKit. It does not, however, preserve
+style/whitespace like `tomlkit` does. For most use-cases, arguably TOML reading
+is the important part...
+
+## Plug-in or Core?
+As for adding the dependency, there are two options:
+- Add separate `pypyr.toml` plugin in its own repo.
+- Add TOML parsing to the pypyr core itself.
+
+pypyr has a [third party
+library](https://pypyr.io/docs/contributing/contribute-to-pypyr/#roll-your-own-plug-in)
+principle that _generally_ external dependencies should get their own repo, to
+keep the pypyr core as light as possible.
+
+However, on pypyr's roadmap is adding a configuration file for setting pypyr
+run-time properties. Much as .yaml would be the more sensible format, given
+pypyr already natively _lives_ in yaml, the increased adoption of
+`pyproject.toml` in the Python eco-system not only by `setuptools` but also
+widely used popular Python tools & libraries does mean that pypyr probably
+shouldn't be the sole tool to demand users keep a separate .config file just for
+it. A feature request for `pyproject.toml` has already come in.
+
+So, were it the case that TOML parsing would only involve a context parser and
+read/write/format steps, it definitely should isolate itself in its on repo. But
+given the need to parse `pyproject.toml` as a core config store, it makes sense
+to add it to the core.
+
+The only remaining point to consider is whether to add the core dependency for
+all pypyr installs, or to make the user specifically have to request the
+functionality via `extras_require` - i.e `$ pip install pypyr[toml]`.
+
+If pypyr is to pull core config information out of `pyproject.toml` as a default
+start-up option, this is fundamental enough that I'm hesitant to introduce extra
+installation friction to get this working without surprises. Given that at worst
+the downside is having an unused TOML library in site-packages for what is
+likely to be a dev virtual environment anyway & a slightly longer install time
+(this in itself cached & fast because it is just a pure Python package), given
+the amount of dependencies in a modern Python dev environment this is arguably a
+drop in the ocean. Given how many `pyproject.toml` compliant tools use `tomli`
+already, there is a pretty good chance the library will exist in a dev vevn
+already anyway.
+
+(Also, I get the sense I'm maybe one of the three last
+people in this solar system who still even cares about whether a given library
+is pulling in too many dependencies.)
+
+## Decision
+Add `tomli` + `tomli-w` to the pypyr core as part of the default install.

--- a/pypyr/loaders/file.py
+++ b/pypyr/loaders/file.py
@@ -141,7 +141,7 @@ def get_pipeline_definition(pipeline_name, parent):
 
     Returns:
         PipelineDefinition describing the pipeline. The dict parsed from the
-            pipeline yaml is in it .pipeline property.
+            pipeline yaml is in its .pipeline property.
     """
     logger.debug("starting")
 
@@ -164,11 +164,15 @@ def get_pipeline_definition(pipeline_name, parent):
 def load_pipeline_from_file(path):
     """Load pipeline yaml from path on disk.
 
+    Initialize a PipelineFileInfo for the pipeline with file loader specific
+    properties.
+
     Args:
         path (Path-like): path to pipeline
 
     Returns:
-        dict describing the pipeline, parsed from the pipeline yaml.
+        PipelineDefinition describing the pipeline, parsed from the yaml file
+            at path.
 
     Raises:
         FileNotFoundError: path not found.

--- a/pypyr/parser/tomlfile.py
+++ b/pypyr/parser/tomlfile.py
@@ -1,0 +1,28 @@
+"""Context parser that returns a dict-like from a toml file."""
+import logging
+
+import pypyr.toml as toml
+
+logger = logging.getLogger(__name__)
+
+
+def get_parsed_context(args):
+    """Parse input as path to a toml file, returns dict of toml contents."""
+    logger.debug("starting")
+    if not args:
+        logger.debug("pipeline invoked without context arg set. For this toml "
+                     "parser you're looking for something like: $ pypyr "
+                     "pipelinename ./myfile.toml")
+        return None
+
+    path = ' '.join(args)
+    logger.debug("attempting to open file: %s", path)
+    payload = toml.read_file(path)
+
+    # no special check whether top-level is mapping necessary, by spec toml
+    # can only have mapping (key-value pairs or table) at top level.
+
+    logger.debug("toml file parsed. Count: %d", len(payload))
+
+    logger.debug("done")
+    return payload

--- a/pypyr/parser/yamlfile.py
+++ b/pypyr/parser/yamlfile.py
@@ -1,6 +1,5 @@
 """Context parser that returns a dictionary from a local yaml file."""
-
-from collections.abc import MutableMapping
+from collections.abc import Mapping
 import logging
 import ruamel.yaml as yaml
 
@@ -22,7 +21,7 @@ def get_parsed_context(args):
         yaml_loader = yaml.YAML(typ='safe', pure=True)
         payload = yaml_loader.load(yaml_file)
 
-    if not isinstance(payload, MutableMapping):
+    if not isinstance(payload, Mapping):
         raise TypeError("yaml input should describe a dictionary at the top "
                         "level. You should have something like\n"
                         "key1: value1\n key2: value2\n"

--- a/pypyr/steps/fetchjson.py
+++ b/pypyr/steps/fetchjson.py
@@ -1,5 +1,5 @@
 """pypyr step that loads json file into context."""
-from collections.abc import MutableMapping
+from collections.abc import Mapping
 import json
 import logging
 from pypyr.utils.asserts import assert_key_has_value
@@ -66,7 +66,7 @@ def run_step(context):
                      destination_key)
         context[destination_key] = payload
     else:
-        if not isinstance(payload, MutableMapping):
+        if not isinstance(payload, Mapping):
             raise TypeError(
                 'json input should describe an object at the top '
                 'level when fetchJsonKey isn\'t specified. You should have '

--- a/pypyr/steps/fetchjson.py
+++ b/pypyr/steps/fetchjson.py
@@ -69,7 +69,7 @@ def run_step(context):
         if not isinstance(payload, Mapping):
             raise TypeError(
                 'json input should describe an object at the top '
-                'level when fetchJsonKey isn\'t specified. You should have '
+                'level when fetchJson.key isn\'t specified. You should have '
                 'something like {"key1": "value1", "key2": "value2"} '
                 'in the json top-level, not ["value1", "value2"]')
 

--- a/pypyr/steps/fetchtoml.py
+++ b/pypyr/steps/fetchtoml.py
@@ -25,7 +25,7 @@ def run_step(context):
                     - key. string. If exists, write toml structure to this
                       context key. Else toml writes to context root.
 
-    Also supports a passing path as string to fetchToml, but in this case you
+    Also supports passing a path as string to fetchToml, but in this case you
     won't be able to specify a key.
 
     All inputs support formatting expressions.

--- a/pypyr/steps/fetchtoml.py
+++ b/pypyr/steps/fetchtoml.py
@@ -1,0 +1,75 @@
+"""pypyr step that loads toml file into context."""
+import logging
+
+import pypyr.toml as toml
+from pypyr.utils.asserts import assert_key_has_value
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Load a toml file into the pypyr context.
+
+    toml parsed from the file will be merged into the pypyr context. This will
+    overwrite existing values if the same keys are already in there.
+    I.e if file toml has
+    eggs = "boiled"
+    and context {'eggs': 'fried'} already exists, returned context['eggs'] will
+    be 'boiled'.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context key must exist
+                - fetchToml
+                    - path. path-like. Path to file on disk.
+                    - key. string. If exists, write toml structure to this
+                      context key. Else toml writes to context root.
+
+    Also supports a passing path as string to fetchToml, but in this case you
+    won't be able to specify a key.
+
+    All inputs support formatting expressions.
+
+    Returns:
+        None. updates context arg.
+
+    Raises:
+        FileNotFoundError: take a guess
+        pypyr.errors.KeyNotInContextError: fetchToml.path missing in context.
+        pypyr.errors.KeyInContextHasNoValueError: fetchToml.path exists but is
+                                                  None.
+
+    """
+    logger.debug("started")
+
+    context.assert_key_has_value(key='fetchToml', caller=__name__)
+
+    fetch_toml_input = context.get_formatted('fetchToml')
+
+    if isinstance(fetch_toml_input, str):
+        file_path = fetch_toml_input
+        destination_key = None
+    else:
+        assert_key_has_value(obj=fetch_toml_input,
+                             key='path',
+                             caller=__name__,
+                             parent='fetchToml')
+        file_path = fetch_toml_input['path']
+        destination_key = fetch_toml_input.get('key', None)
+
+    logger.debug("attempting to open file: %s", file_path)
+
+    payload = toml.read_file(file_path)
+
+    if destination_key:
+        logger.debug("toml file loaded. Writing to context %s",
+                     destination_key)
+        context[destination_key] = payload
+    else:
+        # toml by definition has Mapping on top level, no need to check,
+        logger.debug("toml file loaded. Merging into pypyr context...")
+        context.update(payload)
+
+    logger.info("toml file written into pypyr context. Count: %s",
+                len(payload))
+    logger.debug("done")

--- a/pypyr/steps/fetchyaml.py
+++ b/pypyr/steps/fetchyaml.py
@@ -1,5 +1,5 @@
 """pypyr step that loads yaml file into context."""
-from collections.abc import MutableMapping
+from collections.abc import Mapping
 import logging
 import ruamel.yaml as yaml
 from pypyr.utils.asserts import assert_key_has_value
@@ -65,7 +65,7 @@ def run_step(context):
                      destination_key)
         context[destination_key] = payload
     else:
-        if not isinstance(payload, MutableMapping):
+        if not isinstance(payload, Mapping):
             raise TypeError(
                 "yaml input should describe a dictionary at the top "
                 "level when fetchYamlKey isn't specified. You should have "

--- a/pypyr/steps/fetchyaml.py
+++ b/pypyr/steps/fetchyaml.py
@@ -68,7 +68,7 @@ def run_step(context):
         if not isinstance(payload, Mapping):
             raise TypeError(
                 "yaml input should describe a dictionary at the top "
-                "level when fetchYamlKey isn't specified. You should have "
+                "level when fetchYaml.key isn't specified. You should have "
                 "something like \n'key1: value1'\n key2: value2'\n"
                 "in the yaml top-level, not \n'- value1\n - value2'")
 

--- a/pypyr/steps/fileformattoml.py
+++ b/pypyr/steps/fileformattoml.py
@@ -1,0 +1,48 @@
+"""pypyr step that parses toml file for string substitutions, writes output."""
+import logging
+from pypyr.steps.dsl.fileinoutrewriter import ObjectRewriterStep
+from pypyr.utils.filesystem import TomlRepresenter
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Parse input toml file and substitute {tokens} from context.
+
+    Loads toml into memory to do parsing, so be aware of big files.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                - fileFormatToml
+                    - in. mandatory.
+                      str, path-like, or an iterable (list/tuple) of
+                      strings/paths. Each str/path can be a glob, relative or
+                      absolute path.
+                    - out. optional. path-like.
+                      Can refer to a file or a directory.
+                      will create directory structure if it doesn't exist. If
+                      in-path refers to >1 file (e.g it's a glob or list), out
+                      path can only be a directory - it doesn't make sense to
+                      write >1 file to the same single file (this is not an
+                      appender.) To ensure out_path is read as a directory and
+                      not a file, be sure to have the path separator (/) at the
+                      end.
+                      If out_path is not specified or None, will in-place edit
+                      and overwrite the in-files.
+
+    Returns:
+        None.
+
+    Raises:
+        FileNotFoundError: take a guess
+        pypyr.errors.KeyNotInContextError: fileFormatToml or
+            fileFormatToml['in'] missing in context.
+        pypyr.errors.KeyInContextHasNoValueError: fileFormatToml or
+            fileFormatToml['in'] exists but is None.
+    """
+    logger.debug("started")
+
+    ObjectRewriterStep(__name__, 'fileFormatToml', context).run_step(
+        TomlRepresenter())
+
+    logger.debug("done")

--- a/pypyr/steps/filewrite.py
+++ b/pypyr/steps/filewrite.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 
-from pypyr.utils.asserts import assert_key_is_truthy
+from pypyr.utils.asserts import assert_key_exists, assert_key_is_truthy
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,11 @@ def run_step(context):
                          key='path',
                          caller=__name__,
                          parent='fileWrite')
+
+    assert_key_exists(obj=file_write,
+                      key='payload',
+                      caller=__name__,
+                      parent='fileWrite')
 
     path = Path(file_write['path'])
     is_append = file_write.get('append', False)

--- a/pypyr/steps/filewritejson.py
+++ b/pypyr/steps/filewritejson.py
@@ -7,6 +7,8 @@ from pypyr.utils.asserts import assert_key_has_value
 
 logger = logging.getLogger(__name__)
 
+sentinel = object()
+
 
 def run_step(context):
     """Write payload out to json file.
@@ -43,16 +45,16 @@ def run_step(context):
     # doing it like this to safeguard against accidentally dumping all context
     # with potentially sensitive values in it to disk if payload exists but is
     # None.
-    is_payload_specified = 'payload' in input_context
+    payload = input_context.get('payload', sentinel)
 
     logger.debug("opening destination file for writing: %s", out_path)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if is_payload_specified:
-        payload = input_context['payload']
-    else:
+    if payload is sentinel:
         payload = context.get_formatted_value(context)
+    else:
+        payload = input_context['payload']
 
     with open(out_path, 'w') as outfile:
         json.dump(payload, outfile,

--- a/pypyr/steps/filewritejson.py
+++ b/pypyr/steps/filewritejson.py
@@ -49,12 +49,12 @@ def run_step(context):
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(out_path, 'w') as outfile:
-        if is_payload_specified:
-            payload = input_context['payload']
-        else:
-            payload = context.get_formatted_value(context)
+    if is_payload_specified:
+        payload = input_context['payload']
+    else:
+        payload = context.get_formatted_value(context)
 
+    with open(out_path, 'w') as outfile:
         json.dump(payload, outfile,
                   indent=2, ensure_ascii=False)
 

--- a/pypyr/steps/filewritetoml.py
+++ b/pypyr/steps/filewritetoml.py
@@ -1,0 +1,71 @@
+"""pypyr step that writes payload out to a toml file."""
+import logging
+from pathlib import Path
+
+from pypyr.errors import KeyInContextHasNoValueError
+import pypyr.toml as toml
+from pypyr.utils.asserts import assert_key_has_value
+
+logger = logging.getLogger(__name__)
+
+sentinel = object()
+
+
+def run_step(context):
+    """Write payload out to toml file.
+
+    Args:
+        context: pypyr.context.Context. Mandatory.
+                 The following context keys expected:
+                - fileWriteToml
+                    - path. mandatory. path-like. Write output file to
+                      here. Will create directories in path for you.
+                    - payload. optional. Write this key to output file. If not
+                      specified, output entire context.
+
+    If you do specify a payload, it cannot be None or empty.
+
+    Returns:
+        None.
+
+    Raises:
+        pypyr.errors.KeyNotInContextError: fileWriteToml or
+            fileWriteToml.path missing in context.
+        pypyr.errors.KeyInContextHasNoValueError: fileWriteToml or
+            fileWriteToml.path exists but is None.
+
+    """
+    logger.debug("started")
+
+    input_key_name = 'fileWriteToml'
+    context.assert_key_has_value(input_key_name, __name__)
+
+    input_context = context.get_formatted(input_key_name)
+    assert_key_has_value(obj=input_context,
+                         key='path',
+                         caller=__name__,
+                         parent=input_key_name)
+
+    out_path = Path(input_context['path'])
+    # doing it like this to safeguard against accidentally dumping all context
+    # with potentially sensitive values in it to disk if payload exists but is
+    # None.
+    payload = input_context.get('payload', sentinel)
+
+    if payload is sentinel:
+        payload = context.get_formatted_value(context)
+    else:
+        if not payload:
+            raise KeyInContextHasNoValueError(
+                "payload must have a value to write to output TOML document.")
+
+        payload = input_context['payload']
+
+    logger.debug("opening destination file for writing: %s", out_path)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    toml.write_file(out_path, payload)
+
+    logger.info("formatted context content and wrote to %s", out_path)
+    logger.debug("done")

--- a/pypyr/steps/filewriteyaml.py
+++ b/pypyr/steps/filewriteyaml.py
@@ -51,12 +51,12 @@ def run_step(context):
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(out_path, 'w') as outfile:
-        if is_payload_specified:
-            payload = input_context['payload']
-        else:
-            payload = context.get_formatted_value(context)
+    if is_payload_specified:
+        payload = input_context['payload']
+    else:
+        payload = context.get_formatted_value(context)
 
+    with open(out_path, 'w') as outfile:
         yaml_writer.dump(payload, outfile)
 
     logger.info("formatted context content and wrote to %s", out_path)

--- a/pypyr/steps/filewriteyaml.py
+++ b/pypyr/steps/filewriteyaml.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from pypyr.utils.asserts import assert_key_has_value
 import pypyr.yaml
 
-# logger means the log level will be set correctly
 logger = logging.getLogger(__name__)
+
+sentinel = object()
 
 
 def run_step(context):
@@ -43,7 +44,7 @@ def run_step(context):
     # doing it like this to safeguard against accidentally dumping all context
     # with potentially sensitive values in it to disk if payload exists but is
     # None.
-    is_payload_specified = 'payload' in input_context
+    payload = input_context.get('payload', sentinel)
 
     yaml_writer = pypyr.yaml.get_yaml_parser_roundtrip_for_context()
 
@@ -51,10 +52,10 @@ def run_step(context):
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if is_payload_specified:
-        payload = input_context['payload']
-    else:
+    if payload is sentinel:
         payload = context.get_formatted_value(context)
+    else:
+        payload = input_context['payload']
 
     with open(out_path, 'w') as outfile:
         yaml_writer.dump(payload, outfile)

--- a/pypyr/steps/jsonparse.py
+++ b/pypyr/steps/jsonparse.py
@@ -1,10 +1,11 @@
 """pypyr step that parses a json string to context."""
-from collections.abc import MutableMapping
+from collections.abc import Mapping
 import json
 import logging
 from pypyr.errors import KeyInContextHasNoValueError
 from pypyr.utils.asserts import assert_key_exists
-# logger means the log level will be set correctly
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,7 +56,7 @@ def run_step(context):
                      destination_key)
         context[destination_key] = payload
     else:
-        if not isinstance(payload, MutableMapping):
+        if not isinstance(payload, Mapping):
             raise TypeError(
                 'json input should describe an object at the top '
                 'level when jsonParse.key isn\'t specified. You should have '

--- a/pypyr/toml.py
+++ b/pypyr/toml.py
@@ -1,0 +1,33 @@
+"""Toml handling."""
+import tomli as toml_reader
+import tomli_w as toml_writer
+
+
+def read_file(path):
+    """Read toml file at path and return object.
+
+    Args:
+        path (Path-like): Read file from this location.
+
+    Returns:
+        dict.
+    """
+    with open(path, 'rb') as file:
+        return toml_reader.load(file)
+
+
+def write_file(path, payload):
+    """Write payload to path as a toml file.
+
+    payload should not be None.
+
+    Args:
+        path (Path-like): Write file to this location.
+        payload (dict-like): Serialize this object to toml string & write to
+                             path.
+
+    Returns:
+        None.
+    """
+    with open(path, 'wb') as file:
+        toml_writer.dump(payload, file)

--- a/pypyr/toml.py
+++ b/pypyr/toml.py
@@ -13,7 +13,7 @@ def read_file(path):
         dict.
     """
     with open(path, 'rb') as file:
-        return toml_reader.load(file)
+        return load(file)
 
 
 def write_file(path, payload):
@@ -30,4 +30,34 @@ def write_file(path, payload):
         None.
     """
     with open(path, 'wb') as file:
-        toml_writer.dump(payload, file)
+        dump(payload, file)
+
+
+def load(file):
+    """Read open file object as toml.
+
+    File-like MUST be open in binary mode.
+
+    Args:
+        file (file-like): Open file-like object.
+
+    Returns:
+        dict
+    """
+    return toml_reader.load(file)
+
+
+def dump(payload, file):
+    """Write payload to open file-like object.
+
+    File-like MUST be open in binary mode.
+
+    Args:
+        file (file-like): Open file-like object.
+        payload (dict-like): Serialize this object to toml string & write to
+                             file.
+
+    Returns:
+        None.
+    """
+    toml_writer.dump(payload, file)

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '5.0.0'
+__version__ = '5.1.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.0
+current_version = 5.1.0
 
 [bumpversion:file:pypyr/version.py]
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['python-dateutil', 'ruamel.yaml'],
+    install_requires=['python-dateutil', 'ruamel.yaml', 'tomli', 'tomli-w'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/testfiles/test.toml
+++ b/tests/testfiles/test.toml
@@ -1,0 +1,3 @@
+key1 = "value1"
+key2 = "value2"
+key3 = "value3"

--- a/tests/testfiles/testsubst.toml
+++ b/tests/testfiles/testsubst.toml
@@ -1,0 +1,10 @@
+key1 = "{k1}value !£$% *"
+
+["key2_{k2}"]
+abc = "{k3} def {k4}"
+def = [
+  "l1",
+  "l2 {k5}",
+  "l3",
+]
+k21 = "value"

--- a/tests/unit/pypyr/parser/tomlfile_test.py
+++ b/tests/unit/pypyr/parser/tomlfile_test.py
@@ -1,0 +1,51 @@
+"""tomlfile.py unit tests."""
+from unittest.mock import mock_open, patch
+
+import pytest
+
+import pypyr.parser.tomlfile as toml_file
+
+
+def test_toml_parser_file_open_fails_on_arbitrary_string():
+    """Non path-y input string should fail."""
+    with pytest.raises(FileNotFoundError):
+        toml_file.get_parsed_context('value 1,value 2, value3')
+
+
+def test_toml__parser_file_open_returns_none_on_empty_string():
+    """Non path-y input string should fail."""
+    assert toml_file.get_parsed_context('') is None
+
+
+def test_toml_parser_file_open_returns_none_on_none():
+    """Non path-y input string should fail."""
+    assert toml_file.get_parsed_context(None) is None
+
+
+def test_toml_parser_pass():
+    """Path should pass to toml parser and return parsed toml as dict."""
+    in_bytes = b'[table]\nkey= "value"'
+
+    with patch('pypyr.toml.open',
+               mock_open(read_data=in_bytes)) as mocked_open:
+        out = toml_file.get_parsed_context(['./myfile.toml'])
+
+    mocked_open.assert_called_once_with('./myfile.toml', 'rb')
+
+    assert out == {'table': {'key': 'value'}}
+
+
+def test_toml_parser_spaces():
+    """Unescaped path with spaces pass."""
+    in_bytes = b'key= "value"'
+
+    with patch('pypyr.toml.open',
+               mock_open(read_data=in_bytes)) as mocked_open:
+        out = toml_file.get_parsed_context(['/mydir/sub/one',
+                                            'two/my',
+                                            'file.toml'])
+
+    mocked_open.assert_called_once_with('/mydir/sub/one two/my file.toml',
+                                        'rb')
+
+    assert out == {'key': 'value'}

--- a/tests/unit/pypyr/steps/fetchtoml_test.py
+++ b/tests/unit/pypyr/steps/fetchtoml_test.py
@@ -1,0 +1,158 @@
+"""fetchtoml.py unit tests."""
+from unittest.mock import mock_open, patch
+
+import pytest
+from tomli import TOMLDecodeError
+
+from pypyr.context import Context
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
+import pypyr.steps.fetchtoml as tomlfetcher
+
+
+def test_fetch_toml_no_path_raises():
+    """None path raises."""
+    context = Context({
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        tomlfetcher.run_step(context)
+
+    assert str(err_info.value) == ("context['fetchToml'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.fetchtoml.")
+
+
+def test_fetch_toml_empty_path_raises():
+    """Empty path raises."""
+    context = Context({
+        'fetchToml': {
+            'path': None}})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        tomlfetcher.run_step(context)
+
+    assert str(err_info.value) == ("context['fetchToml']['path'] must have a "
+                                   "value for pypyr.steps.fetchtoml.")
+
+
+def test_fetch_toml_pass():
+    """Relative path to toml should succeed.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fetchToml': {
+            'path': './tests/testfiles/test.toml'}})
+
+    tomlfetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 5, "context should have 5 items"
+    assert context['ok1'] == 'ov1'
+    assert 'fetchTomlPath' not in context
+    assert context["key1"] == "value1", "key1 should be value2"
+    assert context["key2"] == "value2", "key2 should be value2"
+    assert context["key3"] == "value3", "key3 should be value2"
+
+
+def test_fetch_toml_pass_with_string():
+    """Relative path to toml should succeed with string input.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fetchToml': './tests/testfiles/test.toml'})
+
+    tomlfetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 5, "context should have 5 items"
+    assert context['ok1'] == 'ov1'
+    assert 'fetchTomlPath' not in context
+    assert context["key1"] == "value1", "key1 should be value2"
+    assert context["key2"] == "value2", "key2 should be value2"
+    assert context["key3"] == "value3", "key3 should be value2"
+
+
+def test_fetch_toml_pass_with_path_substitution():
+    """Relative path to toml should succeed, with string subsitution on path.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fileName': 'test',
+        'fetchToml': {
+            'path': './tests/testfiles/{fileName}.toml'}})
+
+    tomlfetcher.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 6, "context should have 6 items"
+    assert context['ok1'] == 'ov1'
+    assert 'fetchTomlPath' not in context
+    assert context["key1"] == "value1", "key1 should be value2"
+    assert context["key2"] == "value2", "key2 should be value2"
+    assert context["key3"] == "value3", "key3 should be value2"
+
+
+def test_fetchtoml_with_destination():
+    """Toml writes to destination key."""
+    context = Context({
+        'fetchToml': {
+            'path': '/arb/arbfile',
+            'key': 'outkey'}})
+
+    toml_bytes = b'k1 = "v1"\nk2 = "v2"'
+    with patch('pypyr.toml.open', mock_open(read_data=toml_bytes)):
+        tomlfetcher.run_step(context)
+
+    assert context['outkey'] == {'k1': 'v1', 'k2': 'v2'}
+    assert len(context) == 2
+
+
+def test_fetchtoml_with_destination_int():
+    """Toml writes to destination key that's not a string."""
+    context = Context({
+        'fetchToml': {
+            'path': '/arb/arbfile',
+            'key': 99}})
+
+    toml_bytes = b'k1 = "v1"\nk2 = "v2"'
+    with patch('pypyr.toml.open', mock_open(read_data=toml_bytes)):
+        tomlfetcher.run_step(context)
+
+    assert context[99] == {'k1': 'v1', 'k2': 'v2'}
+    assert len(context) == 2
+
+
+def test_fetchtoml_with_destination_formatting():
+    """Toml writes to destination key found by formatting expression."""
+    context = Context({
+        'keyhere': {'sub': ['outkey', 2, 3]},
+        'fetchToml': {
+            'path': '/arb/arbfile',
+            'key': '{keyhere[sub][0]}'}})
+
+    toml_bytes = b'1 = 2\n2 = 3'
+    with patch('pypyr.toml.open', mock_open(read_data=toml_bytes)):
+        tomlfetcher.run_step(context)
+
+    assert len(context) == 3
+    # toml spec always interprets keys as strings
+    assert context['outkey'] == {'1': 2, '2': 3}
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
+
+
+def test_fetchtoml_invalid_toml_fails():
+    """Invalid toml document fails to load."""
+    context = Context({
+        'ok1': 'ov1',
+        'fetchToml': {
+            'path': '/arb/arbfile'}})
+
+    with patch('pypyr.toml.open', mock_open(read_data=b'[1,2,3]')):
+        with pytest.raises(TOMLDecodeError):
+            tomlfetcher.run_step(context)

--- a/tests/unit/pypyr/steps/fileformattoml_test.py
+++ b/tests/unit/pypyr/steps/fileformattoml_test.py
@@ -1,0 +1,243 @@
+"""fileformattoml.py unit tests."""
+import os
+import shutil
+
+import pytest
+
+from pypyr.context import Context
+from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
+import pypyr.steps.fileformattoml as fileformat
+
+
+# region validation
+def test_fileformattoml_no_in_obj_raises():
+    """None in path raises."""
+    context = Context({
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        fileformat.run_step(context)
+
+    assert str(err_info.value) == (
+        "fileFormatToml not found in the pypyr context.")
+
+
+def test_fileformattoml_no_inpath_raises():
+    """None in path raises."""
+    context = Context({
+        'fileFormatToml': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        fileformat.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileFormatToml']['in'] doesn't exist. It must exist for "
+        "pypyr.steps.fileformattoml.")
+
+
+def test_fileformattoml_empty_inpath_raises():
+    """Empty in path raises."""
+    context = Context({
+        'fileFormatToml': {'in': None}})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        fileformat.run_step(context)
+
+    assert str(err_info.value) == ("context['fileFormatToml']['in'] must have "
+                                   "a value for pypyr.steps.fileformattoml.")
+
+
+# endregion validation
+
+# region integration tests
+def test_fileformattoml_pass_no_substitutions():
+    """Relative path to file should succeed.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fileFormatToml': {'in': './tests/testfiles/test.toml',
+                           'out': './tests/testfiles/out/out.toml'}})
+
+    fileformat.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 2, "context should have 2 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fileFormatToml'] == {
+        'in': './tests/testfiles/test.toml',
+        'out': './tests/testfiles/out/out.toml'}
+
+    with open('./tests/testfiles/out/out.toml') as outfile:
+        outcontents = outfile.read()
+
+    assert outcontents == """key1 = "value1"
+key2 = "value2"
+key3 = "value3"
+"""
+    # atrociously lazy test clean-up
+    os.remove('./tests/testfiles/out/out.toml')
+
+
+def test_fileformattoml_pass_to_out_dir():
+    """Relative path to file should succeed with out dir rather than full path.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'ok1': 'ov1',
+        'fileFormatToml': {'in': './tests/testfiles/test.toml',
+                           'out': './tests/testfiles/out/'}})
+
+    fileformat.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 2, "context should have 2 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fileFormatToml'] == {
+        'in': './tests/testfiles/test.toml',
+        'out': './tests/testfiles/out/'}
+
+    with open('./tests/testfiles/out/test.toml') as outfile:
+        outcontents = outfile.read()
+
+    assert outcontents == """key1 = "value1"
+key2 = "value2"
+key3 = "value3"
+"""
+    # atrociously lazy test clean-up
+    os.remove('./tests/testfiles/out/test.toml')
+
+
+def test_fileformattoml_edit_no_substitutions():
+    """Relative path to file should succeed, no out means in place edit.
+
+    Strictly speaking not a unit test.
+    """
+    shutil.copyfile('./tests/testfiles/test.toml',
+                    './tests/testfiles/out/edittest.toml')
+
+    context = Context({
+        'ok1': 'ov1',
+        'fileFormatToml': {'in': './tests/testfiles/out/edittest.toml'}})
+
+    fileformat.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 2, "context should have 2 items"
+    assert context['ok1'] == 'ov1'
+    assert context['fileFormatToml'] == {
+        'in': './tests/testfiles/out/edittest.toml'}
+
+    with open('./tests/testfiles/out/edittest.toml') as outfile:
+        outcontents = outfile.read()
+
+    assert outcontents == """key1 = "value1"
+key2 = "value2"
+key3 = "value3"
+"""
+
+    # atrociously lazy test clean-up
+    os.remove('./tests/testfiles/out/edittest.toml')
+
+
+def test_fileformattoml_pass_with_substitutions():
+    """Relative path to file should succeed.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'k1': 'v1',
+        'k2': 'v2',
+        'k3': 'v3',
+        'k4': 'v4',
+        'k5': 'v5',
+        'fileFormatToml': {'in': './tests/testfiles/testsubst.toml',
+                           'out': './tests/testfiles/out/outsubst.toml'}})
+
+    fileformat.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 6, "context should have 6 items"
+    assert context['k1'] == 'v1'
+    assert context['fileFormatToml'] == {
+        'in': './tests/testfiles/testsubst.toml',
+        'out': './tests/testfiles/out/outsubst.toml'}
+
+    with open('./tests/testfiles/out/outsubst.toml') as outfile:
+        outcontents = outfile.read()
+
+    expected = """key1 = "v1value !£$% *"
+
+[key2_v2]
+abc = "v3 def v4"
+def = [
+    "l1",
+    "l2 v5",
+    "l3",
+]
+k21 = "value"
+"""
+
+    assert outcontents == expected
+
+    # atrociously lazy test clean-up
+    os.remove('./tests/testfiles/out/outsubst.toml')
+
+
+def test_fileformattoml_pass_with_path_substitutions():
+    """Relative path to file should succeed with path subsitutions.
+
+    Strictly speaking not a unit test.
+    """
+    context = Context({
+        'k1': 'v1',
+        'k2': 'v2',
+        'k3': 'v3',
+        'k4': 'v4',
+        'k5': 'v5',
+        'pathIn': 'testsubst',
+        'pathOut': 'outsubst',
+        'fileFormatToml': {'in': './tests/testfiles/{pathIn}.toml',
+                           'out': './tests/testfiles/out/{pathOut}.toml'}})
+
+    fileformat.run_step(context)
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 8, "context should have 8 items"
+    assert context['k1'] == 'v1'
+    assert context['fileFormatToml'] == {
+        'in': './tests/testfiles/{pathIn}.toml',
+        'out': './tests/testfiles/out/{pathOut}.toml'}
+
+    with open('./tests/testfiles/out/outsubst.toml') as outfile:
+        outcontents = outfile.read()
+
+    expected = """key1 = "v1value !£$% *"
+
+[key2_v2]
+abc = "v3 def v4"
+def = [
+    "l1",
+    "l2 v5",
+    "l3",
+]
+k21 = "value"
+"""
+
+    assert outcontents == expected
+
+    # atrociously lazy test clean-up
+    os.remove('./tests/testfiles/out/outsubst.toml')
+
+# endregion integration tests
+
+# region teardown
+
+
+def teardown_module(module):
+    """Teardown."""
+    os.rmdir('./tests/testfiles/out/')
+
+# endregion teardown

--- a/tests/unit/pypyr/steps/filewrite_test.py
+++ b/tests/unit/pypyr/steps/filewrite_test.py
@@ -100,9 +100,24 @@ def test_filewrite_no_path_raises():
                                    "pypyr.steps.filewrite.")
 
 
+def test_filewrite_no_payload_raises():
+    """No payload raises."""
+    context = Context({
+        'fileWrite': {
+            'path': 'arb'
+        }})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == ("context['fileWrite']['payload'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.filewrite.")
 # endregion validation
 
 # region write text
+
+
 @patch('pypyr.steps.filewrite.Path')
 def test_filewrite_pass_with_payload(mock_path):
     """Success case writes only specific context payload."""

--- a/tests/unit/pypyr/steps/filewritetoml_test.py
+++ b/tests/unit/pypyr/steps/filewritetoml_test.py
@@ -1,0 +1,310 @@
+"""filewritetoml.py unit tests."""
+import io
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from pypyr.context import Context
+from pypyr.errors import (
+    ContextError,
+    KeyInContextHasNoValueError,
+    KeyNotInContextError)
+import pypyr.steps.filewritetoml as filewrite
+
+
+def test_filewritetoml_no_filewritetoml_raises():
+    """No input fileWriteToml raises."""
+    context = Context({
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWriteToml'] doesn't exist. "
+        "It must exist for pypyr.steps.filewritetoml.")
+
+
+def test_filewritetoml_none_filewritetoml_raises():
+    """None fileWriteToml raises."""
+    context = Context({
+        'k1': 'v1',
+        'fileWriteToml': None})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWriteToml'] must have a value for "
+        "pypyr.steps.filewritetoml.")
+
+
+def test_filewritetoml_filewritetoml_not_iterable_raises():
+    """Not iterable fileWriteToml raises."""
+    context = Context({
+        'k1': 'v1',
+        'fileWriteToml': 1})
+
+    with pytest.raises(ContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWriteToml'] must exist, be iterable "
+        "and contain 'path' for pypyr.steps.filewritetoml. argument of type "
+        "'int' is not iterable")
+
+
+def test_filewritetoml_empty_path_raises():
+    """Empty path raises."""
+    context = Context({
+        'fileWriteToml': {
+            'path': None
+        }})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == (
+        "context['fileWriteToml']['path'] must have a value for "
+        "pypyr.steps.filewritetoml.")
+
+
+def test_filewritetoml_no_path_raises():
+    """No path raises."""
+    context = Context({
+        'fileWriteToml': 'blah',
+        'k1': 'v1'})
+
+    with pytest.raises(KeyNotInContextError) as err_info:
+        filewrite.run_step(context)
+
+    assert str(err_info.value) == ("context['fileWriteToml']['path'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.filewritetoml.")
+
+
+@patch('pypyr.steps.filewritetoml.Path')
+def test_filewritetoml_pass_no_payload(mock_path):
+    """Success case writes all context out when no payload."""
+    context = Context({
+        'k1': 'v1',
+        'fileWriteToml': {
+            'path': '/arb/blah'
+        }})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.toml.open', mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        output = out_bytes.getvalue().decode()
+
+    mocked_path = mock_path.return_value
+    mock_path.assert_called_once_with('/arb/blah')
+    mock_output.assert_called_once_with(mocked_path, 'wb')
+    assert context, "context shouldn't be None"
+    assert len(context) == 2, "context should have 2 items"
+    assert context['k1'] == 'v1'
+    assert context['fileWriteToml'] == {'path': '/arb/blah'}
+
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+
+    # toml well formed & new lines and indents are where they should be
+    assert output == 'k1 = "v1"\n\n[fileWriteToml]\npath = "/arb/blah"\n'
+
+
+@patch('pypyr.steps.filewritetoml.Path')
+def test_filewritetoml_pass_with_payload(mock_path):
+    """Success case writes only specific context payload."""
+    context = Context({
+        'k1': 'v1',
+        'fileWriteToml': {
+            'path': '/arb/blah',
+            'payload': {
+                'one': 'v1',
+                'two': True,
+                'three': {'a': 'b', 'c': 123.45,
+                          'd': [0, 1, 2]},
+                'four': 12,
+                'five': True
+            }}})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.toml.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        output = out_bytes.getvalue().decode()
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 2, "context should have 2 items"
+    assert context['k1'] == 'v1'
+
+    assert context['fileWriteToml'] == {'path': '/arb/blah',
+                                        'payload': {
+                                            'one': 'v1',
+                                            'two': True,
+                                            'three': {'a': 'b', 'c': 123.45,
+                                                      'd': [0, 1, 2]},
+                                            'four': 12,
+                                            'five': True
+                                        }}
+
+    mock_path.assert_called_once_with('/arb/blah')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'wb')
+
+    # toml well formed & new lines + indents are where they should be
+    assert output == ('one = "v1"\n'
+                      'two = true\n'
+                      'four = 12\n'
+                      'five = true\n'
+                      '\n'
+                      '[three]\n'
+                      'a = "b"\n'
+                      'c = 123.45\n'
+                      'd = [\n'
+                      '    0,\n'
+                      '    1,\n'
+                      '    2,\n'
+                      ']\n')
+
+
+@patch('pypyr.steps.filewritetoml.Path')
+def test_filewritetoml_pass_no_payload_substitutions(mock_path):
+    """Success case writes all context out with substitutions."""
+    context = Context({
+        'k1': 'v1',
+        'pathkey': '/arb/path',
+        'parent': [0, 1, {'child': '{k1}'}],
+        'nested': '{parent[2][child]}',
+        'fileWriteToml': {
+            'path': '{pathkey}'
+        }})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.toml.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        output = out_bytes.getvalue().decode()
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 5, "context should have 5 items"
+    assert context['k1'] == 'v1'
+    assert context['fileWriteToml'] == {'path': '{pathkey}'}
+
+    mock_path.assert_called_once_with('/arb/path')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'wb')
+
+    # toml well formed & new lines + indents are where they should be
+    assert output == ('k1 = "v1"\n'
+                      'pathkey = "/arb/path"\n'
+                      'parent = [\n'
+                      '    0,\n'
+                      '    1,\n'
+                      '    { child = "v1" },\n'
+                      ']\n'
+                      'nested = "v1"\n'
+                      '\n'
+                      '[fileWriteToml]\n'
+                      'path = "/arb/path"\n')
+
+
+@patch('pypyr.steps.filewritetoml.Path')
+def test_filewritetoml_pass_with_payload_substitutions(mock_path):
+    """Success case writes only specified context with substitutions."""
+    context = Context({
+        'k1': 'v1',
+        'intkey': 3,
+        'pathkey': '/arb/path',
+        'parent': [0,
+                   1,
+                   {'child': ['{k1}',
+                              '{intkey}',
+                              ['a', 'b', 'c']
+                              ]}],
+        'nested': '{parent[2][child]}',
+        'fileWriteToml': {
+            'path': '{pathkey}',
+            'payload': '{parent[2]}'
+        }})
+
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.toml.open',
+                   mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            filewrite.run_step(context)
+
+        output = out_bytes.getvalue().decode()
+
+    assert context, "context shouldn't be None"
+    assert len(context) == 6, "context should have 6 items"
+    assert context['k1'] == 'v1'
+    assert context['fileWriteToml'] == {'path': '{pathkey}',
+                                        'payload': '{parent[2]}'}
+    assert context['parent'] == [0,
+                                 1,
+                                 {'child': ['{k1}',
+                                            '{intkey}',
+                                            ['a', 'b', 'c']
+                                            ]
+                                  }
+                                 ]
+
+    mock_path.assert_called_once_with('/arb/path')
+    mocked_path = mock_path.return_value
+    mocked_path.parent.mkdir.assert_called_once_with(parents=True,
+                                                     exist_ok=True)
+    mock_output.assert_called_once_with(mocked_path, 'wb')
+
+    # toml well formed & new lines + indents are where they should be
+    assert output == ('child = [\n'
+                      '    "v1",\n'
+                      '    3,\n'
+                      '    [\n'
+                      '        "a",\n'
+                      '        "b",\n'
+                      '        "c",\n'
+                      '    ],\n'
+                      ']\n')
+
+
+def test_filewritetoml_fail_with_empty_payload():
+    """Empty payload does not write empty file."""
+    context = Context({
+        'k1': 'v1',
+        'fileWriteToml': {
+            'path': '/arb/blah',
+            'payload': ''
+        }})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        filewrite.run_step(context)
+
+    assert str(err.value) == (
+        'payload must have a value to write to output TOML document.')
+
+
+def test_filewritetoml_fail_with_none_payload():
+    """None payload does not write empty file."""
+    context = Context({
+        'k1': 'v1',
+        'fileWriteToml': {
+            'path': '/arb/blah',
+            'payload': None
+        }})
+
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        filewrite.run_step(context)
+
+    assert str(err.value) == (
+        'payload must have a value to write to output TOML document.')

--- a/tests/unit/pypyr/toml_test.py
+++ b/tests/unit/pypyr/toml_test.py
@@ -1,0 +1,89 @@
+"""Unit tests for toml.py."""
+import io
+from unittest.mock import mock_open, patch
+
+from pypyr.context import Context
+import pypyr.toml as toml
+
+
+def test_toml_file_roundtrip():
+    """Read toml file, edit it, dump it."""
+    in_bytes = b"""[table]
+foo = "bar"  # String
+baz = 13
+
+[table2]
+array = [1, 2, 3]
+"""
+
+    # read
+    with patch('pypyr.toml.open',
+               mock_open(read_data=in_bytes)) as mocked_open:
+        payload = toml.read_file('arb/path.in')
+
+    mocked_open.assert_called_once_with('arb/path.in', 'rb')
+
+    assert payload['table']['baz'] == 13
+    assert payload['table2']['array'] == [1, 2, 3]
+
+    # add like you would to a normall dict
+    payload['table3'] = {'a': 'b', 'c': True}
+
+    # write
+    with io.BytesIO() as out_bytes:
+        with patch('pypyr.toml.open', mock_open()) as mock_output:
+            mock_output.return_value.write.side_effect = out_bytes.write
+            toml.write_file('arb/out.toml', payload)
+        out_str = out_bytes.getvalue().decode()
+
+    mock_output.assert_called_once_with('arb/out.toml', 'wb')
+
+    # round-tripped serialization has table3 as added from python dict obj
+    assert out_str == """[table]
+foo = "bar"
+baz = 13
+
+[table2]
+array = [
+    1,
+    2,
+    3,
+]
+
+[table3]
+a = "b"
+c = true
+"""
+
+
+def test_toml_context_interop():
+    """Toml object works with pypyr Context."""
+    in_bytes = b"""k1 = "v1"
+    k2 = "start{k1}end"
+    k3 = 3
+
+    [table]
+    array = [1, 2, "{k3}"]
+    """
+
+    # read
+    with patch('pypyr.toml.open',
+               mock_open(read_data=in_bytes)) as mocked_open:
+        toml_obj = toml.read_file('arb/path.in')
+
+    mocked_open.assert_called_once_with('arb/path.in', 'rb')
+
+    # load toml obj into Context
+    context = Context(toml_obj)
+
+    # toml obj works with context formatting/merging methods
+    assert context.get_formatted('k2') == 'startv1end'
+    assert context.get_formatted_value(context['table']) == {'array':
+                                                             [1, 2, 3]}
+
+    context.merge({'table': {'array': [4, 5]}})
+    assert context.get_formatted_value(context['table']['array']) == [1,
+                                                                      2,
+                                                                      3,
+                                                                      4,
+                                                                      5]

--- a/tests/unit/pypyr/utils/filesystem_test.py
+++ b/tests/unit/pypyr/utils/filesystem_test.py
@@ -1,10 +1,14 @@
-"""fileformat.py unit tests."""
+"""fileformat.py unit tests.
+
+The bulk of coverage is in tests/integration/pypyr/utils/filesystem_int_test.py
+"""
 import io
-import pytest
 from unittest.mock import mock_open
+
+import pytest
 import pypyr.utils.filesystem as filesystem
 
-# ------------------------ FileRewriter ---------------------------------------
+# region FileRewriter
 
 
 def test_filerewriter_abstract():
@@ -23,9 +27,9 @@ def test_filerewriter_in_to_out_abstract():
 
     with pytest.raises(NotImplementedError):
         x.in_to_out('blah')
-# ------------------------ END of FileRewriter --------------------------------
+# endregion FileRewriter
 
-# ------------------------ ObjectRepresenter ----------------------------------
+# region ObjectRepresenter
 
 
 def test_objectrepresenter_abstract():
@@ -35,7 +39,7 @@ def test_objectrepresenter_abstract():
 
 
 def test_object_representer_abc_methods():
-    """Abstract methods do nothing."""
+    """Abstract methods do nothing and mode defaults."""
     class MyRepresenter(filesystem.ObjectRepresenter):
         def load(self, file):
             super().load(file)
@@ -47,10 +51,17 @@ def test_object_representer_abc_methods():
     x.load(None)
     x.dump(None, None)
 
+    # defaults for mode is text read or write.
+    assert x.read_mode == 'rt'
+    assert x.write_mode == 'wt'
+
 
 def test_json_representer():
     """Json representer load and dump payload."""
     representer = filesystem.JsonRepresenter()
+
+    assert representer.read_mode == 'rt'
+    assert representer.write_mode == 'wt'
 
     in_json = '{"a": "b", "c": [1,2,true]}'
     obj = representer.load(mock_open(read_data=in_json)())
@@ -72,9 +83,38 @@ def test_json_representer():
                                        '}')
 
 
+def test_toml_representer():
+    """Toml representer load and dump payload."""
+    representer = filesystem.TomlRepresenter()
+
+    assert representer.read_mode == 'rb'
+    assert representer.write_mode == 'wb'
+
+    in_toml = b'a = "b"\nc = [1,2,true]'
+    with mock_open(read_data=in_toml)() as f:
+        obj = representer.load(f)
+
+    assert obj == {'a': 'b', 'c': [1, 2, True]}
+
+    with io.BytesIO() as out_bytes:
+        mock_output = mock_open()
+        mock_output.return_value.write.side_effect = out_bytes.write
+        representer.dump(mock_output(), obj)
+
+        assert out_bytes.getvalue().decode() == ('a = "b"\n'
+                                                 'c = [\n'
+                                                 '    1,\n'
+                                                 '    2,\n'
+                                                 '    true,\n'
+                                                 ']\n')
+
+
 def test_yaml_representer():
     """Yaml representer load and dump payload."""
     representer = filesystem.YamlRepresenter()
+
+    assert representer.read_mode == 'rt'
+    assert representer.write_mode == 'wt'
 
     in_yaml = ('a: b\n'
                'c:\n'
@@ -96,9 +136,9 @@ def test_yaml_representer():
                                        '  - 2\n'
                                        '  - true\n')
 
-# ------------------------ END ObjectRepresenter ------------------------------
+# endregion ObjectRepresenter
 
-# ------------------------ is_same_file --------------------------------------
+# region is_same_file
 
 
 def test_is_same_file_none():
@@ -106,4 +146,4 @@ def test_is_same_file_none():
     assert not filesystem.is_same_file(None, '')
 
 
-# ------------------------ END is_same_file -----------------------------------
+# endregion is_same_file


### PR DESCRIPTION
Add toml functionality to the pypyr core.

See `docs/adr/0003-toml-in-core.md` for full rationale. In summary: adds the tomli + tomli+w dependencies to the pypyr core, with the usual context parser and file read/write steps.

- Add `tomli` + `tomli-w` packages to `install_requires` - will install with standard pypyr installation as a dependency. These 3rd party libs handle toml functionality.
- Add `pypyr.toml` to encapsulate all toml serialization/deserialization functions
- Add toml file context parser
- Add `pypyr.steps.fetchtoml` to read toml file into context as an object
- Add `pypyr.steps.filewritetoml` to write context to output toml file
- Add `pypyr.steps.fileformattoml` to read input toml, replace {formatting expressions} and write to output file.
  - To make this work, necessitates adding `is_binary` to `pypyr.utils.filesystem.ObjectRewriter` to open files for reading/writing in binary mode, in addition to existing text mode functionality.
  - The `ObjectRewriter` gets the necessary file-mode (binary vs text) from two new props on the `Representer` - `read_mode` and `write_mode`. 
  - `JsonRepresenter` & `TomlRepresenter` continues to use default text mode.
  - `TomlRepresenter` uses binary mode. 
- minor optimization refactor of `fileWriteJson` & `fileWriteToml` to use sentinel object rather than double dict look-up.
- minor refactor to have json/toml steps check against `Mapping` rather than `MutableMapping` when validating that the top-level of the json/yaml document describes an object (json) or mapping (yaml).
- add friendlier explicit error validation msg if the `payload` input doesn't exist in `pypyr.steps.filewrite`
- some minor typos fixed.
- Version bump for minor release.

Closes #134. 