### PR TITLE
FakePath PathLike & parent also fake

### DIFF
--- a/pypyr/config.py
+++ b/pypyr/config.py
@@ -393,7 +393,7 @@ class Config():
             out.write('config_loaded_paths:\n')
             out.write(''.join(f'  - {k}\n' for k in self._config_loaded_paths))
         else:
-            out.write('config_loaded_paths:[]\n')
+            out.write('config_loaded_paths: []\n')
 
         out.write(f'cwd: {self.cwd}\n')
 

--- a/tests/common/path_mock.py
+++ b/tests/common/path_mock.py
@@ -72,9 +72,17 @@ class FakePath():
         """Pretend to be PosixPath or WindowsPath, depending on os."""
         return type(self.path)
 
+    def __eq__(self, other):
+        """Allow equality check to work as per path."""
+        return self.path == other
+
     def __instancecheck__(self, instance):
         """Allow me to masquerade as an actual Path object."""
         return isinstance(instance, Path)
+
+    def __fspath__(self):
+        """Implement os.PathLike interface."""
+        return str(self.path)
 
     def exists(self):
         """Fake exists not actually to touch the filesystem.
@@ -113,7 +121,8 @@ class FakePath():
         underlying_attr = getattr(self.path, attr)
 
         if not callable(underlying_attr):
-            return underlying_attr
+            return FakePath(underlying_attr) if isinstance(
+                underlying_attr, Path) else underlying_attr
 
         # wrap the delegated callable so you can
         # capture the args+kwargs when callable

--- a/tests/common/path_mock_test.py
+++ b/tests/common/path_mock_test.py
@@ -10,6 +10,8 @@ def test_fake_path():
     """A FakePath behaves like a Path."""
     fp = FakePath('/arb')
     assert isinstance(fp, Path)
+    assert isinstance(fp, os.PathLike)
+    assert fp.__fspath__() == f'{os.sep}arb'
     assert str(fp) == f'{os.sep}arb'
 
     # mocked out methods don't touch the file system
@@ -21,6 +23,7 @@ def test_fake_path():
     assert fp.is_dir() is False
 
     # delegate to underlying path
+    assert fp.name == 'arb'
     fp.mock_instance.joinpath.assert_not_called()
     assert fp.joinpath('sub') == Path('/arb/sub')
 
@@ -42,6 +45,16 @@ def test_fake_path():
     fp.mock.return_value.joinpath.assert_called_once_with('sub')
     fp.mock.return_value.is_dir.assert_called_once()
     fp.mock_instance.is_dir.assert_called_once()
+
+
+def test_fake_path_parent():
+    """Methods returning Paths return FakePaths."""
+    fp = FakePath('/arb/sub')
+    parent = fp.parent
+    assert fp.mock.mock_calls == [call('/arb/sub')]
+    assert fp.mock.parent.mock_calls == []
+    assert type(parent) is FakePath
+    assert parent == Path('/arb')
 
 
 def test_fake_path_constructor_overrides():

--- a/tests/unit/pypyr/config_test.py
+++ b/tests/unit/pypyr/config_test.py
@@ -739,7 +739,7 @@ vars: {}
 
 COMPUTED PROPERTIES:
 
-config_loaded_paths:[]
+config_loaded_paths: []
 """ + f'cwd: {CWD}' + f"""
 is_macos: {is_macos}
 is_posix: {is_posix}

--- a/tests/unit/pypyr/steps/fileformattoml_test.py
+++ b/tests/unit/pypyr/steps/fileformattoml_test.py
@@ -1,12 +1,17 @@
 """fileformattoml.py unit tests."""
+from unittest.mock import call, patch
+
 import pytest
 
 from pypyr.context import Context
 from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
 import pypyr.steps.fileformattoml as fileformat
 
+from tests.common.path_mock import MultiPath, FakePath
 
 # region validation
+
+
 def test_fileformattoml_no_in_obj_raises():
     """None in path raises."""
     context = Context({
@@ -243,21 +248,35 @@ k21 = "value"
     assert outcontents == expected
 
 
-def test_fileformattoml_with_encoding():
-    """Toml parses binary for utf-8 only, no encoding."""
+@patch('pypyr.utils.filesystem.os.path.isfile', return_value=True)
+@patch('pypyr.utils.filesystem.os.path.samefile', return_value=False)
+def test_fileformattoml_with_encoding(patch_samefile, patch_isfile):
+    """Toml parses binary for utf-8 only, no encoding allowed."""
     # currently no fakefs here because of bug
     # https://github.com/jmcgeheeiv/pyfakefs/issues/664
     # for this test to work it still touches the real filesystem, therefore
     # ./tests/testfiles/test.toml needs to exist.
     # Can remove this testfile soon as update to pyfakefs live.
+
     context = Context({
         'ok1': 'ov1',
         'fileFormatToml': {'in': './tests/testfiles/test.toml',
                            'out': 'test/out/output.toml',
                            'encoding': 'utf-16'}})
 
+    fake_in = FakePath('./tests/testfiles/test.toml',
+                       is_file=True)
+
+    mock_paths = MultiPath(known={'./tests/testfiles/test.toml': fake_in})
+
     with pytest.raises(ValueError) as err:
-        fileformat.run_step(context)
+        with patch('pypyr.utils.filesystem.Path', new=mock_paths):
+            fileformat.run_step(context)
 
     assert str(err.value) == "binary mode doesn't take an encoding argument"
+
+    assert mock_paths.instances[0].mock.mock_calls == [
+        call('test/out/output.toml'), call().is_dir()]
+
+    assert mock_paths.instances[1] is fake_in
 # endregion functional tests


### PR DESCRIPTION
- On FakePath('/arb').parent, delegate to underlying `Path`, but wrap response in `FakePath`.
  - Previously just allowing the `FakePath` to return .parent as a `Path` meant that operations like `mkdir` against the parent would not be faked but go to the real filesystem instead.
- Make `FakePath` equality check pass when comparing against Path by overriding `__eq__` to check against Path.
- Make `FakePath` pass `os.PathLike` abc type check by adding the `__fspath__()` method. Per spec, it returns a string representation of the path.

- Also minor typography fix to `pypyr.config` str output - add space to empty `config_loaded_paths` output between the `:` and `[]` to standardize it to look like all the others.