### PR TITLE
pypyr.steps.python & version bump 5.2.0

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -28,26 +28,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"      
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
       - name: tox cache
         id: tox-cache
         uses: actions/cache@v2
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-tox-
+          key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.py') }}
 
       - name: Run build pipeline for linting, testing & packaging verification.
         uses: pypyr/run-in-tox-action@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,27 +13,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"      
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
       - name: tox cache
         id: tox-cache
         uses: actions/cache@v2
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-tox-
-              
+          key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.py') }}
+
       - name: Run publish pipeline
         uses: pypyr/run-in-tox-action@main
         with:

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -22,26 +22,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+          cache: pip
 
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"      
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: tox cache
         id: tox-cache
         uses: actions/cache@v2
         with:
           path: .tox
-          key: ${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-tox-
+          key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.py') }}
 
       - name: run tag pipeline.
         uses: pypyr/run-in-tox-action@main

--- a/ops/build.yaml
+++ b/ops/build.yaml
@@ -139,10 +139,7 @@ get_version:
       echoMe: version is {version}
 
 set_config:
-  - name: pypyr.steps.pyimport
-    in:
-      pyImport: import sys
-  
+  - pypyr.steps.python
   - name: pypyr.steps.default
     comment: set configuration parameters & vars used throughout pipeline.
     in:
@@ -152,7 +149,6 @@ set_config:
         output_coverage: xml:{output_results_dir}/codecoverage/coverage.xml
         output_test_results: "{output_results_dir}/testresults/junitresults.xml"
         argList: null
-        python: !py sys.executable
   - pypyr.steps.configvars
   - name: pypyr.steps.assert
     description: --> check expected keys in pypyr-config.yaml

--- a/pypyr/steps/python.py
+++ b/pypyr/steps/python.py
@@ -1,0 +1,17 @@
+"""pypyr step that gets the full path to the current Python executable."""
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Get the full path to the current Python executable.
+
+    Args:
+        Context is a dictionary or dictionary-like.
+        Does not require any specific keys in context.
+    """
+    logger.debug("started")
+    context['python'] = sys.executable
+    logger.debug("done")

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '5.1.0'
+__version__ = '5.2.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.2.0
 
 [bumpversion:file:pypyr/version.py]
 

--- a/tests/unit/pypyr/steps/python_test.py
+++ b/tests/unit/pypyr/steps/python_test.py
@@ -1,0 +1,13 @@
+"""python.py unit tests."""
+import sys
+
+from pypyr.context import Context
+import pypyr.steps.python
+
+
+def test_python_executable():
+    """Python executable writes into context."""
+    context = Context()
+    pypyr.steps.python.run_step(context)
+    assert context['python'] == sys.executable
+    assert len(context) == 1


### PR DESCRIPTION
- add `pypyr.steps.python` steps to write value of current Python executable into context. See #265
  - amend ops/build to use this new step and `{python}` in subsequent cmds running Python as a subprocess from pypyr
- now that upstream `pyfakefs` released patch, amend unit tests for passing encoding to a binary mode where an error is expected.
- minor release version bump