### PR TITLE
Shortcuts

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -29,12 +29,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: tox cache
-        id: tox-cache
-        uses: actions/cache@v2
-        with:
-          path: .tox
-          key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.py') }}
 
       - name: Run build pipeline for linting, testing & packaging verification.
         uses: pypyr/run-in-tox-action@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,12 +14,6 @@ jobs:
         with:
           python-version: '3.x'
           cache: pip
-      - name: tox cache
-        id: tox-cache
-        uses: actions/cache@v2
-        with:
-          path: .tox
-          key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.py') }}
 
       - name: Run publish pipeline
         uses: pypyr/run-in-tox-action@main

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -24,13 +24,6 @@ jobs:
           python-version: '3.x'
           cache: pip
 
-      - name: tox cache
-        id: tox-cache
-        uses: actions/cache@v2
-        with:
-          path: .tox
-          key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.py') }}
-
       - name: run tag pipeline.
         uses: pypyr/run-in-tox-action@main
         with:

--- a/pypyr/pipeline.py
+++ b/pypyr/pipeline.py
@@ -198,8 +198,12 @@ class Pipeline():
                 skip_parse = shortcut.get('skip_parse')
                 # flip the bit - skip_parse means inverse of parse_args, but
                 # only if it exists
+                # since cli always set parse_args=True, the shortcut has
+                # entirely to ignore the cli input to allow shortcut to calc
+                # if parse_input should True/False based on args and
+                # parser_args availability.
                 parse_input = (
-                    parse_input if skip_parse is None else not skip_parse)
+                    None if skip_parse is None else not skip_parse)
 
                 shortcut_dict_in = shortcut.get('args')
                 if shortcut_dict_in:
@@ -494,7 +498,6 @@ class Pipeline():
             Boolean. True if should parse input.
         """
         if parse_args is None:
-            return not (args_in is None and dict_in is not None)
-
+            return not (not args_in and dict_in is not None)
         return parse_args
     # endregion cli context input args

--- a/pypyr/steps/pype.py
+++ b/pypyr/steps/pype.py
@@ -112,22 +112,24 @@ def run_step(context):
     pype_args = get_arguments(context)
 
     try:
-        pipeline = Pipeline(name=pype_args.pipeline_name,
-                            context_args=pype_args.pipe_arg,
-                            parse_input=not pype_args.skip_parse,
-                            loader=pype_args.loader,
-                            groups=pype_args.step_groups,
-                            success_group=pype_args.success_group,
-                            failure_group=pype_args.failure_group,
-                            py_dir=pype_args.py_dir)
+        pipeline, args = Pipeline.new_pipe_and_args(
+            name=pype_args.pipeline_name,
+            context_args=pype_args.pipe_arg,
+            parse_input=not pype_args.skip_parse,
+            dict_in=pype_args.args,
+            loader=pype_args.loader,
+            groups=pype_args.step_groups,
+            success_group=pype_args.success_group,
+            failure_group=pype_args.failure_group,
+            py_dir=pype_args.py_dir)
 
         if pype_args.use_parent_context:
             logger.info("pyping %s, using parent context.",
                         pype_args.pipeline_name)
 
-            if pype_args.args:
+            if args:
                 logger.debug("writing args into parent context...")
-                context.update(pype_args.args)
+                context.update(args)
 
             pipeline.load_and_run_pipeline(context, pype_args.parent)
 
@@ -135,10 +137,7 @@ def run_step(context):
             logger.info("pyping %s, without parent context.",
                         pype_args.pipeline_name)
 
-            if pype_args.args:
-                child_context = Context(pype_args.args)
-            else:
-                child_context = Context()
+            child_context = Context(args) if args else Context()
 
             pipeline.load_and_run_pipeline(child_context, pype_args.parent)
 

--- a/tests/unit/pypyr/pipeline_test.py
+++ b/tests/unit/pypyr/pipeline_test.py
@@ -1,4 +1,9 @@
-"""pipeline.py unit tests."""
+"""pipeline.py unit tests.
+
+A lot of the tests for the Pipeline.new_pipe_and_args factory constructor
+exist in ./pipelinerunner_test.py, which tests at a higher level that the
+inputs from a run request map as expected into the Pipeline instance.
+"""
 import logging
 from unittest.mock import call, patch, Mock
 

--- a/tests/unit/pypyr/pipelinerunner_test.py
+++ b/tests/unit/pypyr/pipelinerunner_test.py
@@ -475,7 +475,7 @@ def test_run_shortcut_minimal(mock_pipe, monkeypatch):
 
 
 def test_run_shortcut_parse_args(mock_pipe, monkeypatch):
-    """Run shortcut honors parse_args from func input."""
+    """Run shortcut bypasses parse_args from func input."""
     shortcuts = {'arb pipe': {
         'pipeline_name': 'sc pipe'
     }}
@@ -487,10 +487,11 @@ def test_run_shortcut_parse_args(mock_pipe, monkeypatch):
     assert out == {}
     assert not out.is_in_pipeline_scope
 
+    # when neither parser_args and args set, default True on parse_input.
     mock_pipe.assert_called_once_with(
         name='sc pipe',
         context_args=None,
-        parse_input=False,
+        parse_input=True,
         groups=None,
         success_group=None,
         failure_group=None,


### PR DESCRIPTION
- Shortcuts. 
  - save shortcut for pipeline run commands to context, to allow operator to run longer pipeline sequences with the short and sweet alias
  - to make this work more easily, create classmethod factory on `pypyr.pipeline.Pipeline` that returns a new `Pipeline` from `config.shortcuts` if matching shortcut found.
  -  closing #267
 - Somewhere in the last year or two, Python's `argparse` module looks like it got a new bug in that `default` isn't honored on nargs.
  - Result is that pypyr's  `args_in` nargs initialize to `[]` rather than `None` as specified and as it should.
  - It so happens that this wouldn't have caused drama for pypyr, because at worst API users who specified `arg_parse=False` would just have redundantly run the `context_parser`, if it exists. But all the built-in `context_parsers` do a truthy `None` check on the args input anyway, so this wouldn't have failed.
  - Therefore, change logic of `Pipeline._get_parse_input` to check truthy on `args_in` rather than `is None`.
- remove tox caching from gh actions.
  - not convinced this cache actually helps the build run faster - tox has to re-check its deps anyway, and the `pip`  install cache is supported by gh action nowadays so the tox configure step should be fast anyway. This might be the case, might not be, let's see.
  