### PR TITLE
async cmds + shells

### DIFF
--- a/ops/tag.yaml
+++ b/ops/tag.yaml
@@ -25,7 +25,7 @@ steps:
         save: True
   - name: pypyr.steps.stopstepgroup
     description: --> tag already exists
-    run: !py cmdOut['stdout'] == f'v{version}'
+    run: !py cmdOut.stdout == f'v{version}'
   - name: pypyr.steps.cmd
     comment: tag current HEAD
     description: --> create new tag for release

--- a/pypyr/aio/__init__.py
+++ b/pypyr/aio/__init__.py
@@ -1,0 +1,1 @@
+"""init py module."""

--- a/pypyr/aio/subproc.py
+++ b/pypyr/aio/subproc.py
@@ -1,0 +1,490 @@
+"""Spawn subprocess asynchronously."""
+# can remove __future__ once py 3.10 the lowest supported version
+from __future__ import annotations
+import asyncio
+from asyncio import subprocess
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+import logging
+from pathlib import Path
+import shlex
+
+from pypyr.config import config
+from pypyr.errors import ContextError, MultiError
+from pypyr.subproc import SimpleCommandTypes, SubprocessResult
+
+logger = logging.getLogger(__name__)
+
+# region windows shlex
+is_windows = config.is_windows
+
+# this code is in fact covered when run on windows (during CI)
+# set no cover so no complaining from coverage on posix
+if is_windows:  # pragma: no cover
+    from ctypes.wintypes import LPWSTR, HLOCAL
+    from ctypes import windll, c_int, POINTER, byref  # type: ignore
+
+    CommandLineToArgvW = windll.shell32.CommandLineToArgvW
+    CommandLineToArgvW.restype = POINTER(LPWSTR)
+
+    LocalFree = windll.kernel32.LocalFree
+    LocalFree.argtypes = [HLOCAL]
+    LocalFree.restype = HLOCAL
+
+
+def winshlex_split(cmd: str) -> list[str]:  # pragma: no cover
+    """Split cmd string into args using Windows api."""
+    num_args = c_int()
+    lp_args = CommandLineToArgvW(cmd, byref(num_args))
+
+    # copy response
+    args = [lp_args[i] for i in range(num_args.value)]
+
+    # must free allocated block of contiguous memory, prevent leaks
+    if LocalFree(lp_args):
+        # return value is None when LocalFree succeeds
+        # on fail return value is handle to the local memory object
+        raise RuntimeError(
+            f"Failed to release {lp_args} after winddll.shell32 "
+            + "CommandLineToArgvW")
+
+    return args
+
+# endregion windows shlex
+
+
+shlexer = winshlex_split if is_windows else shlex.split
+
+
+class Command:
+    """A subprocess run instruction. Use async run() to spawn the subprocess.
+
+    Attributes:
+        cmd (str/bytes/Pathlike or list[str/bytes/Pathlike]): A str for a
+            single run instruction, or a list of str for >1 run instructions.
+        is_shell (bool): Invoke subprocess through the default shell.
+        cwd (Path-like): Current working directory to this during execution.
+        is_save (bool): Save output to self.results.
+        is_text (bool): Treat stdin, stdout & stderr streams as text in the
+            provided encoding, not bytes. This is only relevant when
+            is_save is True.
+        stdout (None | str | Pathlike): Write stdout here. None means inherit
+            the parent's handle, '/dev/null' means to write to the null device,
+            and a path will write to file.
+        stderr (None | str | Pathlike): Write stderr here. None means inherit
+            the parent's handle, '/dev/null' means to write to the null device,
+            '/dev/stdout' redirects to stdout, and a path will write to file.
+        encoding (str): Use this encoding on all the output streams. Default to
+            the system's default encoding. Only applicable if is_save True.
+        append (bool): If stdout/stderr refers to a file path, append to file
+            rather than overwrite if it exists. Only relevant when is_save
+            False.
+        results (list[SubprocessResult]): List of results. Populated with the
+            result of each run instruction in `cmd`. Only when is_save is True.
+    """
+
+    def __init__(self,
+                 cmd,
+                 is_shell=False,
+                 cwd=None,
+                 is_save=False,
+                 is_text=True,
+                 stdout=None,
+                 stderr=None,
+                 encoding=None,
+                 append=False):
+        """Initialize the Cmd."""
+        self.cmd = cmd
+        self.is_shell = is_shell
+        self.cwd = cwd
+        self.is_save = is_save
+        self.is_text = is_text if is_save else False
+
+        if is_save:
+            if stdout or stderr:
+                raise ContextError(
+                    "You can't set `stdout` or `stderr` when `save` is True.")
+            self.stdout = self.stderr = subprocess.PIPE
+        else:
+            self.stdout = stdout
+            self.stderr = stderr
+        self.encoding = encoding if encoding else config.default_cmd_encoding
+        self.append = append
+
+        self._results: list[SubprocessResult | Exception | list] = []
+
+    @property
+    def results(self) -> list[SubprocessResult | Exception | list]:
+        """Results of this Command after run()."""
+        return self._results
+
+    @contextmanager
+    def output_handles(self):
+        """Return stdout + stderr output handles for subprocess.
+
+        If self.stdout or self.stderr are None, will return None for whichever
+        is None. This will result in the subprocess using the parent's handler
+        for that output device.
+
+        If self.stdout or self.stderr refers to a path, will open the file(s)
+        at the given location for writing. Will create parent directories if
+        these do not exist. self.append controls whether to overwrite or append
+        files. Set self.encoding to write in text mode in the given encoding,
+        otherwise the file handle opens in binary mode.
+
+        The context manager will close the file handles (if any) when it exits.
+
+        If self.stdout or self.stderr are the special values subprocess.PIPE,
+        '/dev/null' or '/dev/stdout', will return the appropriate subprocess
+        constants for these.
+
+        Returns:
+            (stdout, stderr): stdout & stderr handles to use when executing
+                this command as a subprocess.
+        """
+        stdout = self.stdout
+        stderr = self.stderr
+        # fast short-circuit when no processing necessary
+        if not stdout and not stderr:
+            #  this works because stdout/stderr will be PIPE when capturing
+            logger.debug("stdout & stderr attaching to parent process.")
+            yield stdout, stderr
+        else:
+            # append or overwrite
+            mode = 'ab' if self.append else 'wb'
+            files = []
+            try:
+                # stdout
+                if stdout == subprocess.PIPE:
+                    logger.debug("capturing stdout")
+                elif stdout == '/dev/null':
+                    logger.debug("redirecting stdout to /dev/null")
+                    stdout = subprocess.DEVNULL
+                elif stdout:
+                    # by elimination, it's a path
+                    logger.debug("writing stdout to %s in mode '%s'",
+                                 stdout, mode)
+                    Path(stdout).parent.mkdir(parents=True, exist_ok=True)
+                    stdout = open(stdout, mode=mode)
+                    files.append(stdout)
+
+                #  stderr
+                if stderr == subprocess.PIPE:
+                    logger.debug("capturing stderr")
+                elif stderr == '/dev/null':
+                    logger.debug("redirecting stderr to /dev/null")
+                    stderr = subprocess.DEVNULL
+                elif stderr == '/dev/stdout':
+                    logger.debug("redirecting stderr to /dev/stdout")
+                    stderr = subprocess.STDOUT
+                elif stderr:
+                    # by elimination, it's a path
+                    logger.debug("writing stderr to %s in mode '%s'",
+                                 stderr, mode)
+                    Path(stderr).parent.mkdir(parents=True, exist_ok=True)
+                    stderr = open(stderr, mode=mode)
+                    files.append(stderr)
+
+                yield stdout, stderr
+            finally:
+                for f in files:
+                    logger.debug("closing cmd file output %s", f.name)
+                    f.close()
+
+    def parse_results(self) -> list[Exception]:
+        """Parse subprocess output for errors.
+
+        Errors are likely to be SubprocessError where returncode != 0.
+
+        If there were problems getting to the subprocess itself (i.e it
+        couldn't even run), likely to be a PermissionError or OSError.
+
+        This does not raise any exceptions, it just returns a list of them.
+
+        Returns:
+            list[Exception]: Flattened list of Exception objects.
+        """
+        errors = []
+        for result in self._results:
+            for error in self._parse_result(result):
+                errors.append(error)
+        return errors
+
+    def _parse_result(self,
+                      result: SubprocessResult | Exception | list
+                      ) -> Iterator[Exception]:
+        """Parse results recursively looking for errors."""
+        if isinstance(result, Exception):
+            yield result
+        elif isinstance(result, SubprocessResult):
+            error = result.check_returncode()
+            if error:
+                yield error
+        elif isinstance(result, list):
+            for nested_result in result:
+                yield from self._parse_result(nested_result)
+        else:
+            # this really should be unreachable.
+            raise TypeError(
+                f"{result} is {type(result)}.\n"
+                + "It should be SubprocessResult | Exception | "
+                + "list[SubprocessResult | Exception].")
+        # don't just add stuff here! remember those yields further up!
+
+    async def run(self) -> None:
+        """Run the command asynchronously as a subprocess.
+
+        Do NOT raise exceptions in here. Add exceptions to self.results
+        instead.
+
+        Typical exceptions that end up in `results`:
+            pypyr.errors.ContextError: The cmd executable instruction is
+                formatted incorrectly.
+            subprocess.CalledProcessError: Error executing the subprocess.
+            FileNotFoundError: The system could not find the executable. It
+                might not be on $PATH, or the path to the executable might be
+                wrong.
+        """
+        cmd = self.cmd
+        try:
+            # this here because all outputs for this cmd write to the same
+            # device/file handles - whether single cmd or list of commands.
+            with self.output_handles() as (stdout, stderr):
+                if isinstance(cmd, SimpleCommandTypes):
+                    # just one command, run as is
+                    try:
+                        result = await self._run(cmd, stdout, stderr)
+                    except Exception as ex:
+                        # mypy currently doesn't like re-using local var name
+                        result = ex  # type: ignore
+
+                    self._results.append(result)
+                elif isinstance(cmd, Sequence):
+                    # Sequence won't be str - explicitly checked before in if
+                    # except weirdness if passing bytearray (ByteString), but
+                    # why would you?
+                    tasks = [self._run(c, stdout, stderr) for c in cmd]
+                    results = await asyncio.gather(*tasks,
+                                                   return_exceptions=True)
+                    # extend results shared state here coz concurrent now done
+                    self._results.extend(results)
+                else:
+                    err = ContextError(
+                        f"{cmd} cmds input.\n"
+                        "Each command should be a simple string, or a "
+                        "sub-list to run in serial:\n"
+                        "cmds:\n"
+                        "  - ./my-executable --arg\n"
+                        "  - ./another-executable --arg\n"
+                        "  - [./executableA.1, ./executableA.2]\n\n"
+                        "Or in the expanded syntax, set `run` to a list:\n"
+                        "cmds:\n"
+                        "  run:\n"
+                        "    - ./my-executable --arg\n"
+                        "    - ./another-executable --arg\n"
+                        "    - [./executableA.1, ./executableA.2]\n"
+                        "  cwd: ./mydir")
+                    self._results.append(err)
+        except Exception as ex:
+            # instead of raising exception, any errs MUST be available on
+            # `results` for this particular cmd (otherwise caller gather of >1
+            # commands won't know _which_ cmd raised the err.)
+            self._results.append(ex)
+
+    async def _run(self, cmd,
+                   stdout=None,
+                   stderr=None
+                   ) -> SubprocessResult | list[SubprocessResult | Exception]:
+        """Spawn subprocess for cmd with stdout + stderr output streams.
+
+        If self.is_save is True, will append the completed process results to
+        self.results, for both success and failure. Will strip trailing
+        whitespace from output.
+
+        A non-zero returncode will not raise error, it returns a
+                SubprocessResult with the details instead. Will raise error
+                if subprocess couldn't even execute at all.
+
+        Args:
+            cmd (str | Pathlike | list): The executable + args to spawn as
+                                a subprocess. If list, will execute cmds in
+                                list in serial.
+            stdout: Write stdout here. This can be None (attach to parent
+                    process), an open file handle, subprocess.PIPE (to capture)
+                    or subprocess.DEVNULL.
+            stderr: Write stderr here. This can be None (attach to parent
+                    process), an open file handle, or subprocess.PIPE (to
+                    capture) or subprocess.DEVNULL, or subprocess.STDOUT to
+                    redirect to stdout.
+
+        Returns:
+            A SubprocessResult or list of SubprocessResult when cmd is a list
+            of serial commands.
+
+        Raises:
+            subprocess.CalledProcessError: Error executing the subprocess.
+            FileNotFoundError: The system could not find the executable. It
+                might not be on $PATH, or the path to the executable might be
+                wrong.
+        """
+        if isinstance(cmd, (list, tuple)):
+            logger.debug(
+                "async %s is a series of commands that will run in serial",
+                cmd)
+            results: list[SubprocessResult | Exception] = []
+            try:
+                for serial_cmd in cmd:
+                    result = await self._spawn(serial_cmd,
+                                               stdout=stdout,
+                                               stderr=stderr)
+                    results.append(result)
+                    # don't proceed to next serial cmd if return code != 0
+                    if result.returncode:
+                        break
+            except Exception as ex:
+                # need to save results as they happen, so if later in sequence
+                # fails, can still return results of preceding serial cmds
+                results.append(ex)
+            return results
+
+        return await self._spawn(cmd, stdout=stdout, stderr=stderr)
+
+    async def _spawn(self, cmd, stdout, stderr) -> SubprocessResult:
+        if self.cwd:
+            logger.debug("Processing command string in dir %s: %s",
+                         self.cwd, self.cmd)
+        else:
+            logger.debug("Processing command string: %s", cmd)
+
+        # errs from _inside_ the subprocess will go to stderr and raise
+        # via check_returncode. errs finding the executable will raise
+        # right here.
+        if self.is_shell:
+            proc = await asyncio.create_subprocess_shell(cmd,
+                                                         stdout=stdout,
+                                                         stderr=stderr,
+                                                         cwd=self.cwd)
+        else:
+            args = shlexer(cmd)  # type: ignore
+            logger.debug("arg split is: %s", args)
+            proc = await asyncio.create_subprocess_exec(args[0],
+                                                        *args[1:],
+                                                        stdout=stdout,
+                                                        stderr=stderr,
+                                                        cwd=self.cwd)
+
+        stdout_data, stderr_data = await proc.communicate()
+
+        if self.is_save:
+            if self.is_text:
+                if stdout_data:
+                    stdout_data = stdout_data.decode(
+                        self.encoding).rstrip()  # type: ignore
+
+                if stderr_data:
+                    stderr_data = stderr_data.decode(
+                        self.encoding).rstrip()  # type: ignore
+
+        return SubprocessResult(cmd=cmd, returncode=proc.returncode,
+                                stdout=stdout_data, stderr=stderr_data)
+
+    def __eq__(self, other):
+        """Check equality for all attributes."""
+        if self is other:
+            return True
+
+        if type(other) is Command:
+            return self.__dict__ == other.__dict__
+
+        return NotImplemented
+
+
+class Commands():
+    """Execute a bunch of Command objects asynchronously.
+
+    Use .append to add a Command to run.
+
+    run() runs every Command appended with .append() in parallel.
+
+    Check results with the `results` property.
+    """
+
+    def __init__(self) -> None:
+        """Initialize commands to run asynchronously."""
+        self.commands: list[Command] = []
+        self._results: list[SubprocessResult | Exception | list] = []  # None
+        self._is_save: bool = False
+
+    def __getitem__(self, index: int) -> Command:
+        """Get Command in collection by index."""
+        return self.commands[index]
+
+    def __iter__(self) -> Iterator[Command]:
+        """Allow iteration through Command instances contained in Commands."""
+        return iter(self.commands)
+
+    def __len__(self) -> int:
+        """Length (count) of Command instances in Commands."""
+        return len(self.commands)
+
+    def append(self, cmd: Command) -> None:
+        """Append a Command to run asynchronously."""
+        if cmd.is_save and not self._is_save:
+            self._is_save = True
+        self.commands.append(cmd)
+
+    @property
+    def is_save(self) -> bool:
+        """Is true when any of the Commands to process has is_save==True."""
+        return self._is_save
+
+    @property
+    def results(self) -> list[SubprocessResult | Exception
+                              | list[SubprocessResult | Exception]]:
+        """Return the aggregate list of results for all the command runs.
+
+        Only contains results where a Command.is_save == True.
+        """
+        return self._results
+
+    def run(self) -> None:
+        """Run all commands as asynchronous subprocesses.
+
+        This is the method that does the work. It contains an asyncio.run(),
+        so you can't call this from an already existing event-loop.
+
+        When this is done, whether it raises an exception or not, you can check
+        `results` on the instance to see outputs for each command.
+
+        Raises:
+            pypyr.errors.MultiError: Aggregate error containing a list of
+                any/all errors that any of the subprocesses might have raised.
+        """
+        asyncio.run(self._run())
+        errors = []
+        for cmd in self.commands:
+            if cmd.is_save:
+                self._results.extend(cmd._results)
+            errs = cmd.parse_results()
+            if errs:
+                errors.extend(errs)
+
+        if errors:
+            raise MultiError(("The following error(s) occurred while running "
+                              + "the async commands:"),
+                             errors)
+
+    async def _run(self) -> None:
+        """Run all commands asynchronously & gather results."""
+        tasks = [cmd.run() for cmd in self.commands]
+        await asyncio.gather(*tasks)
+
+    def __eq__(self, other):
+        """Check equality for Command contained in commands list."""
+        if self is other:
+            return True
+
+        if type(other) is Commands:
+            return self.commands == other.commands
+
+        return NotImplemented

--- a/pypyr/config.py
+++ b/pypyr/config.py
@@ -7,6 +7,7 @@ Attributes:
 from __future__ import annotations
 from collections.abc import Mapping
 from io import StringIO
+import locale
 import os
 from pathlib import Path
 import sys
@@ -50,6 +51,8 @@ class Config():
         log_notify_format: str. Format str for default log output.
         log_detail_format: str. Format str for detailed log output.
         default_backoff: str. Default retry back-off algorithm.
+        default_cmd_encoding: str. Encoding to use on stdout/stderr with
+            subprocess via pypyr.steps.cmd, pypyr.steps.cmds & shell.
         default_encoding: str. Encoding to use when working with files. None
             means to use the system defaults (utf-8, except for Windows.)
         default_loader: str. Default pipeline loader - 'pypyr.loaders.file'
@@ -82,6 +85,7 @@ class Config():
         'log_detail_format',
         # defaults
         'default_backoff',
+        'default_cmd_encoding',
         'default_encoding',
         'default_loader',
         'default_group',
@@ -114,6 +118,8 @@ class Config():
         # defaults
         self.default_backoff = 'fixed'
         # 'utf-8' is a magic string specially optimized in CPython
+        self.default_cmd_encoding: str | None = os.getenv(
+            'PYPYR_CMD_ENCODING', locale.getpreferredencoding(False))
         self.default_encoding: str | None = os.getenv('PYPYR_ENCODING', None)
         self.default_loader = 'pypyr.loaders.file'
         self.default_group = 'steps'

--- a/pypyr/steps/cmds.py
+++ b/pypyr/steps/cmds.py
@@ -1,0 +1,90 @@
+"""pypyr step that runs sub-processes asynchronously.
+
+You cannot use things like exit, return, shell pipes, filename wildcards,
+environment,variable expansion, and expansion of ~ to a user’s home
+directory.
+"""
+import logging
+from pypyr.steps.dsl.cmdasync import AsyncCmdStep
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Run commands, programs or executables asynchronously, in parallel.
+
+    Context is a pypyr.context.Context. This is dict-like.
+
+    Context must contain the following keys:
+        cmds:
+            - <<cmd string 1>>
+            - <<cmd string 2>>
+
+    where <<cmd string>> is command + args to execute.
+
+    You can alternatively use the expanded syntax to override default options:
+
+    cmds:
+        run: list[str | list[str]]. mandatory. command + args to execute.
+            If list entry is another list[str], the sub-list will run in
+            serial.
+        save: bool. defaults False. save output to cmdOut. Treats output
+            as text in the system's encoding and removes newlines at end.
+        cwd: str/Pathlike. optional. Working directory for these commands.
+        bytes (bool): Default False. When `save` return output bytes from
+            cmds unaltered, without applying any encoding & text newline
+            processing.
+        encoding (str): Default None. When `save`, decode output with
+            this encoding. The default of None uses the system encoding and
+            should "just work".
+        stdout (str | Path): Default None. Write stdout to this file path.
+            Special value `/dev/null` writes to the system null device.
+        stderr (str | Path): Default None. Write stderr to this file path.
+            Special value `/dev/null` writes to the system null device.
+            Special value `/dev/stdout` redirects err output to stdout.
+        append (bool): Default False. When stdout/stderr a file, append
+            rather than overwrite. Default is to overwrite.
+
+    In expanded syntax, `run` can be a simple string or a list:
+        cmds:
+          run:
+            - ./my-executable --arg
+            - ./another-executable --arg
+          save: False
+          cwd: ./path/here
+
+    Will execute the command string in the shell as a sub-process.
+    Escape curly braces: if you want a literal curly brace, double it like
+    {{ or }}.
+
+    If save is True, will save the output as a list of results in the order
+    executed. Each result is a pypyr.subproc.SubprocessResult, with the schema:
+    cmd: the cmd/args executed
+    returncode: 0
+    stdout: 'stdout str here. None if empty.'
+    stderr: 'stderr str here. None if empty.'
+
+    cmdOut.returncode is the exit status of the called process. Typically 0
+    means OK. A negative value -N indicates that the child was terminated by
+    signal N (POSIX only).
+
+    If the sub-process couldn't spawn at all (e.g executable not found), the
+    results list will contain the Exception object instead of a
+    SubprocessResult.
+
+    You can find this list of results in context `cmdOut` after step completes.
+
+    context['cmds'] will interpolate anything in curly braces for values
+    found in context. So if your context looks like this:
+        key1: value1
+        key2: value2
+        cmds:
+            - mything --arg1 {key1}
+
+    The cmd passed to the shell will be "mything --arg value1"
+    """
+    logger.debug("started")
+
+    AsyncCmdStep(name=__name__, context=context, is_shell=False).run_step()
+
+    logger.debug("done")

--- a/pypyr/steps/shells.py
+++ b/pypyr/steps/shells.py
@@ -1,9 +1,8 @@
-"""pypyr step that runs sub-processes asynchronously.
+"""pypyr step that executes commands in the shell as a sub-process.
 
-This runs an executable, it does not invoke the shell. Therefore you cannot
-use things like exit, return, shell pipes, filename wildcards,
-environment variable expansion, and expansion of ~ to a user’s home
-directory. See pypyr.steps.shells for shell invocation.
+The command string must be formatted exactly as it would be when typed
+at the shell prompt. This includes, for example, quoting or backslash escaping
+filenames with spaces in them. The shell defaults to /bin/sh on posix.
 """
 import logging
 from pypyr.steps.dsl.cmdasync import AsyncCmdStep
@@ -14,12 +13,14 @@ logger = logging.getLogger(__name__)
 def run_step(context):
     """Run commands, programs or executables asynchronously, in parallel.
 
+    Spawns a shell for each runnable item.
+
     Context is a pypyr.context.Context. This is dict-like.
 
     Context must contain the following keys:
         cmds:
-            - <<cmd string 1>>
-            - <<cmd string 2>>
+            - <<shell string 1>>
+            - <<shell string 2>>
 
     where <<cmd string>> is command + args to execute.
 
@@ -54,7 +55,7 @@ def run_step(context):
           save: False
           cwd: ./path/here
 
-    Will execute the command string in as a sub-process.
+    Will execute the command string in the shell as a sub-process.
     Escape curly braces: if you want a literal curly brace, double it like
     {{ or }}.
 
@@ -82,10 +83,10 @@ def run_step(context):
         cmds:
             - mything --arg1 {key1}
 
-    The cmd passed to the o/s will be "mything --arg value1"
+    The cmd passed to the shell will be "mything --arg value1"
     """
     logger.debug("started")
 
-    AsyncCmdStep(name=__name__, context=context, is_shell=False).run_step()
+    AsyncCmdStep(name=__name__, context=context, is_shell=True).run_step()
 
     logger.debug("done")

--- a/tests/integration/pypyr/steps/cmds_int_test.py
+++ b/tests/integration/pypyr/steps/cmds_int_test.py
@@ -1,0 +1,169 @@
+"""Tests for pypyr.steps.cmds that touch the filesystem.
+
+Can't use pyfakefs for these because the subprocess lib uses C libs to hit the
+fs rather than the patch-able Python files access.
+"""
+from pathlib import Path
+import tempfile
+from unittest import TestCase
+
+import pytest
+
+from pypyr.config import config
+from pypyr.context import Context
+from pypyr.errors import MultiError
+import pypyr.steps.cmds
+
+is_windows = config.is_windows
+
+
+@pytest.fixture
+def temp_dir():
+    """Make tmp dir in testfiles/out. Yields pathlib.Path."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield Path(tmp_dir)
+
+
+def get_cmd(posix, win):
+    """Return posix or win depending on current platform."""
+    return win if is_windows else posix
+
+
+def test_async_cmds_stderr_to_stdout(temp_dir):
+    """Redirect stderr to stdout."""
+    cmd1 = get_cmd('echo one',
+                   r'tests\testfiles\cmds\echo.bat one')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/exitwitherr.sh',
+                   r'tests\testfiles\cmds\exitwitherr.bat')
+
+    cmd3 = get_cmd('echo three',
+                   r'tests\testfiles\cmds\echo.bat three')
+
+    stdout = temp_dir.joinpath('stdout')
+
+    context = Context({
+        'cmds': {
+            'run': [cmd1, cmd2, cmd3],
+            'stdout': stdout,
+            'stderr': '/dev/stdout'}
+    })
+
+    with pytest.raises(MultiError) as ex:
+        pypyr.steps.cmds.run_step(context)
+
+    assert 'cmdOut' not in context
+    err = ex.value
+    assert len(err) == 1
+    assert str(err) == f"""\
+The following error(s) occurred while running the async commands:
+SubprocessError: Command '{cmd2}' returned non-zero exit status 1."""
+
+    out_file_lines = stdout.read_text().rstrip().split('\n')
+    TestCase().assertCountEqual(out_file_lines,
+                                ['one', 'arb err here', 'three'])
+
+
+def test_async_cmds_overwrite_vs_append(temp_dir):
+    """Write to stdout and stderr with append true/false, default overwrite."""
+    stdout = temp_dir.joinpath('mydir/stdout')
+    stderr = temp_dir.joinpath('mydir/stderr')
+
+    cmd1 = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh one',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat one')
+
+    context = Context({
+        'cmds': {
+            'run': [cmd1],
+            'stdout': stdout,
+            'stderr': stderr}
+    })
+
+    pypyr.steps.cmds.run_step(context)
+
+    assert 'cmdOut' not in context
+    assert stdout.read_text() == 'stdout one\n'
+    assert stderr.read_text() == 'stderr one\n'
+
+    # now overwrite these by default on 2nd invocation
+    cmd2 = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh two',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat two')
+
+    context = Context({
+        'cmds': {
+            'run': [cmd2],
+            'stdout': stdout,
+            'stderr': stderr}
+    })
+
+    pypyr.steps.cmds.run_step(context)
+
+    assert stdout.read_text() == 'stdout two\n'
+    assert stderr.read_text() == 'stderr two\n'
+
+    # now append
+    cmd3 = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh three',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat three')
+
+    # list input with element being a dict in expanded syntax
+    context = Context({
+        'cmds': [{
+            'run': [cmd3],
+            'stdout': stdout,
+            'stderr': stderr,
+            'append': True}]
+    })
+
+    pypyr.steps.cmds.run_step(context)
+
+    assert 'cmdOut' not in context
+    assert stdout.read_text() == (
+        'stdout two\nstdout three\n')
+    assert stderr.read_text() == (
+        'stderr two\nstderr three\n')
+
+
+def test_async_cmds_expanded_syntax_on_list_item(temp_dir):
+    """Set stdout/stderr on multiple expanded inputs on base list input."""
+    cmd1 = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh one',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat one')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh two',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat two')
+
+    cmd3 = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh three',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat three')
+
+    stdout1 = temp_dir.joinpath('stdout1')
+    stderr1 = temp_dir.joinpath('stderr1')
+    stdout2 = temp_dir.joinpath('stdout2')
+    stderr2 = temp_dir.joinpath('stderr2')
+
+    context = Context({
+        'cmds': [
+            {
+                'run': [cmd1],
+                'stdout': stdout1,
+                'stderr': stderr1
+            },
+            {
+                'run': [cmd2, cmd3],
+                'stdout': stdout2,
+                'stderr': stderr2}
+        ]})
+
+    pypyr.steps.cmds.run_step(context)
+
+    assert 'cmdOut' not in context
+
+    assert stdout1.read_text() == 'stdout one\n'
+    assert stderr1.read_text() == 'stderr one\n'
+
+    out_file_lines2 = stdout2.read_text().rstrip().split('\n')
+    err_file_lines2 = stderr2.read_text().rstrip().split('\n')
+
+    TestCase().assertCountEqual(out_file_lines2,
+                                ['stdout two', 'stdout three'])
+
+    TestCase().assertCountEqual(err_file_lines2,
+                                ['stderr two', 'stderr three'])

--- a/tests/unit/pypyr/aio/aio_subproc_test.py
+++ b/tests/unit/pypyr/aio/aio_subproc_test.py
@@ -1,0 +1,304 @@
+"""Unit tests for pypyr.aio.subproc."""
+import asyncio.subprocess as subprocess
+
+import pytest
+
+from pypyr.config import config
+from pypyr.errors import ContextError
+from pypyr.aio.subproc import Command, Commands
+
+# region Command
+
+# region ctor
+
+
+def test_async_subproc_minimal():
+    """Create Command with minimal inputs."""
+    cmd = Command('arb')
+    assert cmd.cmd == 'arb'
+    assert cmd.is_shell is False
+    assert cmd.cwd is None
+    assert cmd.is_save is False
+    assert cmd.is_text is False
+    assert cmd.stdout is None
+    assert cmd.stderr is None
+    assert cmd.encoding == config.default_cmd_encoding
+    assert cmd.append is False
+    assert cmd.results == []
+
+
+def test_async_subproc_maximal():
+    """Create Command with maximal inputs."""
+    # is_save
+    cmd = Command('arb',
+                  is_shell=True,
+                  cwd='cwd',
+                  is_save=True,
+                  is_text=True,
+                  encoding='enc',
+                  append=True)
+
+    assert cmd.cmd == 'arb'
+    assert cmd.is_shell is True
+    assert cmd.cwd == 'cwd'
+    assert cmd.is_save is True
+    assert cmd.is_text is True
+    assert cmd.stdout == subprocess.PIPE
+    assert cmd.stderr == subprocess.PIPE
+    assert cmd.encoding == 'enc'
+    assert cmd.append is True
+    assert cmd.results == []
+
+    # not is_save
+    cmd = Command('arb',
+                  is_shell=True,
+                  cwd='cwd',
+                  is_save=False,
+                  is_text=True,
+                  stdout='stdout',
+                  stderr='stderr',
+                  encoding='enc',
+                  append=True)
+
+    assert cmd.cmd == 'arb'
+    assert cmd.is_shell is True
+    assert cmd.cwd == 'cwd'
+    assert cmd.is_save is False
+    assert cmd.is_text is False  # because save is False
+    assert cmd.stdout == 'stdout'
+    assert cmd.stderr == 'stderr'
+    assert cmd.encoding == 'enc'
+    assert cmd.append is True
+    assert cmd.results == []
+
+
+def test_async_subproc_command_no_stdout_on_save():
+    """Raise when combining stdout/stdour with save."""
+    #  stdout
+    with pytest.raises(ContextError) as err:
+        Command('arb', is_save=True, stdout='in')
+
+    assert str(err.value) == (
+        "You can't set `stdout` or `stderr` when `save` is True.")
+
+    #  stderr
+    with pytest.raises(ContextError) as err:
+        Command('arb', is_save=True, stderr='out')
+
+    assert str(err.value) == (
+        "You can't set `stdout` or `stderr` when `save` is True.")
+
+    #  stderr + stdout
+    with pytest.raises(ContextError) as err:
+        Command('arb', is_save=True, stdout='in', stderr='out')
+
+    assert str(err.value) == (
+        "You can't set `stdout` or `stderr` when `save` is True.")
+# endregion ctor
+
+
+def test_async_subproc_command_eq():
+    """Command instance does equality check on all attributes."""
+    c = Command('cmd')
+    assert c == c
+    assert Command('cmd') == Command('cmd')
+    assert Command('cmd') != Command('other')
+
+    assert Command([1, 2, 3]) == Command([1, 2, 3])
+    assert Command([1, 2, 3]) != Command([11, 22, 33])
+
+    assert Command('arb') != 'arb'
+
+    assert Command('cmd',
+                   is_shell=True,
+                   cwd='cwd',
+                   is_save=False,
+                   is_text=True,
+                   stdout='out',
+                   stderr='err',
+                   encoding='enc',
+                   append=True) == Command('cmd',
+                                           is_shell=True,
+                                           cwd='cwd',
+                                           is_save=False,
+                                           is_text=True,
+                                           stdout='out',
+                                           stderr='err',
+                                           encoding='enc',
+                                           append=True)
+
+    assert Command('cmd',
+                   is_shell=False,
+                   cwd='cwd',
+                   is_save=False,
+                   is_text=True,
+                   stdout='out',
+                   stderr='err',
+                   encoding='enc',
+                   append=False) != Command('cmd',
+                                            is_shell=False,
+                                            cwd='cwd',
+                                            is_save=False,
+                                            is_text=True,
+                                            stdout='out',
+                                            stderr='err',
+                                            encoding='enc',
+                                            append=True)
+    assert Command('cmd',
+                   is_shell=True,
+                   cwd='cwd',
+                   is_save=False,
+                   is_text=True,
+                   stdout='out',
+                   stderr='err',
+                   encoding='enc1',
+                   append=True) != Command('cmd',
+                                           is_shell=True,
+                                           cwd='cwd',
+                                           is_save=False,
+                                           is_text=True,
+                                           stdout='out',
+                                           stderr='err',
+                                           encoding='enc2',
+                                           append=True)
+    assert Command('cmd',
+                   is_shell=True,
+                   cwd='cwd',
+                   is_save=True,
+                   is_text=True,
+                   encoding='enc',
+                   append=True) == Command('cmd',
+                                           is_shell=True,
+                                           cwd='cwd',
+                                           is_save=True,
+                                           is_text=True,
+                                           encoding='enc',
+                                           append=True)
+
+    assert [Command('one')] == [Command('one')]
+    assert [Command('one')] != [Command('two')]
+
+    # results
+    cmd1 = Command('cmd')
+    cmd1.results.append('one')
+    cmd2 = Command('cmd')
+    cmd2.results.append('one')
+    assert cmd1 == cmd2
+    cmd2.results.append('two')
+    assert cmd1 != cmd2
+
+# region parse_results
+
+
+def test_async_subproc_command_parse_result_wrong_type():
+    """Results should only contain Exception, SubprocessResult or list."""
+    cmd = Command("arb")
+    # this is pretty artificial - this err is there as a safety mechanism in
+    # case of unforeseen future changes where maybe someone (me?!) forgets
+    # results should only contain Exception, SubprocessResult or list.
+    cmd.results.append(123)
+    with pytest.raises(TypeError) as err:
+        cmd.parse_results()
+
+    # noqa is for line length
+    assert str(err.value) == """\
+123 is <class 'int'>.
+It should be SubprocessResult | Exception | list[SubprocessResult | Exception]."""  # noqa: E501
+# endregion parse_results
+
+# region output_handles
+
+
+def test_async_subproc_command_output_handles_none():
+    """Output handles return None."""
+    cmd = Command('arb')
+    with cmd.output_handles() as (stdout, stderr):
+        assert stdout is None
+        assert stderr is None
+
+
+def test_async_subproc_command_output_handles_pipe():
+    """Output handles to pipe (capture)."""
+    cmd = Command('arb', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    with cmd.output_handles() as (stdout, stderr):
+        assert stdout == subprocess.PIPE
+        assert stderr == subprocess.PIPE
+
+
+def test_async_subproc_command_output_handles_dev_null():
+    """Output handles to /dev/null."""
+    cmd = Command('arb', stdout='/dev/null', stderr='/dev/null')
+    with cmd.output_handles() as (stdout, stderr):
+        assert stdout == subprocess.DEVNULL
+        assert stderr == subprocess.DEVNULL
+
+    cmd = Command('arb', stderr='/dev/null')
+    with cmd.output_handles() as (stdout, stderr):
+        assert stdout is None
+        assert stderr == subprocess.DEVNULL
+
+    cmd = Command('arb', stdout='/dev/null')
+    with cmd.output_handles() as (stdout, stderr):
+        assert stdout == subprocess.DEVNULL
+        assert stderr is None
+
+    cmd = Command('arb', stdout='/dev/null', stderr='/dev/stdout')
+    with cmd.output_handles() as (stdout, stderr):
+        assert stdout == subprocess.DEVNULL
+        assert stderr == subprocess.STDOUT
+# endregion output_handles
+
+# endregion Command
+
+# region Commands
+
+
+def test_async_subproc_commands_iter():
+    """Commands is iterable and index-able."""
+    cmds = Commands()
+    assert len(cmds) == 0
+
+    for c in cmds:
+        raise AssertionError("can't iterate empty")
+
+    cmds.append(Command('a'))
+    cmds.append(Command('b'))
+
+    assert len(cmds) == 2
+
+    out = []
+    for c in cmds:
+        out.append(c)
+
+    assert out == [Command('a'), Command('b')]
+
+    assert cmds[0] == Command('a')
+    assert cmds[1] == Command('b')
+    assert cmds[1] != Command('c')
+
+
+def test_async_subproc_commands_eq():
+    """Command instance does equality check on all attributes."""
+    c = Commands()
+    assert c == c
+
+    empty_cmds = Commands()
+    assert empty_cmds == Commands()
+
+    cmds = Commands()
+    cmds.append(Command('a'))
+
+    assert cmds != empty_cmds
+
+    cmds2 = Commands()
+    cmds2.append(Command('a'))
+
+    assert cmds == cmds2
+    cmds2.append(Command('b'))
+    assert cmds != cmds2
+    cmds.append(Command('b'))
+    assert cmds == cmds2
+
+    assert cmds != 123
+
+# endregion Commands

--- a/tests/unit/pypyr/steps/cmd_step_test.py
+++ b/tests/unit/pypyr/steps/cmd_step_test.py
@@ -97,9 +97,14 @@ def test_cmd_dict_input_with_string_interpolation_save_out():
                                'save': True}})
     pypyr.steps.cmd.run_step(context)
 
+    # dict like accessors only here for backwards compatibility
     assert context['cmdOut']['returncode'] == 0
     assert context['cmdOut']['stdout'] == 'blah'
     assert not context['cmdOut']['stderr']
+
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == 'blah'
+    assert not context['cmdOut'].stderr
 
 
 def test_cmd_dict_input_sequence_with_cwd():
@@ -112,9 +117,9 @@ def test_cmd_dict_input_sequence_with_cwd():
                                'cwd': 'tests'}})
     pypyr.steps.cmd.run_step(context)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert Path(context['cmdOut']['stdout']).samefile('./tests')
-    assert not context['cmdOut']['stderr']
+    assert context['cmdOut'].returncode == 0
+    assert Path(context['cmdOut'].stdout).samefile('./tests')
+    assert not context['cmdOut'].stderr
 
 
 def test_cmd_dict_input_sequence_with_cwd_interpolate():
@@ -132,9 +137,9 @@ def test_cmd_dict_input_sequence_with_cwd_interpolate():
                                'cwd': '{k1}'}})
     pypyr.steps.cmd.run_step(context)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert Path(context['cmdOut']['stdout']).samefile('./tests')
-    assert not context['cmdOut']['stderr']
+    assert context['cmdOut'].returncode == 0
+    assert Path(context['cmdOut'].stdout).samefile('./tests')
+    assert not context['cmdOut'].stderr
 
 
 def test_cmd_error_throws():
@@ -157,9 +162,9 @@ def test_cmd_error_throws_with_save_true():
         context = Context({'cmd': {'run': cmd, 'save': True}})
         pypyr.steps.cmd.run_step(context)
 
-    assert context['cmdOut']['returncode'] == 1
-    assert not context['cmdOut']['stdout']
-    assert context['cmdOut']['stderr'] == 'arb err here'
+    assert context['cmdOut'].returncode == 1
+    assert not context['cmdOut'].stdout
+    assert context['cmdOut'].stderr == 'arb err here'
 
 
 def test_cmd_context_cmd_throw():
@@ -398,9 +403,9 @@ def test_cmd_list_input_with_complex_args_error_on_first_save():
     else:
         assert err.value.cmd == [cmd1, 'WRONG', 'two two', 'three']
     out = context['cmdOut']
-    assert out['returncode'] == 1
-    assert out['stdout'] == ''
-    assert out['stderr'] == 'assert failed'
+    assert out.returncode == 1
+    assert out.stdout == ''
+    assert out.stderr == 'assert failed'
 
 
 def test_cmd_run_has_list_input_save():
@@ -421,14 +426,14 @@ def test_cmd_run_has_list_input_save():
     out = context['cmdOut']
     assert len(out) == 2
     out1 = out[0]
-    assert out1['returncode'] == 0
-    assert out1['stdout'] == 'one'
-    assert not out1['stderr']
+    assert out1.returncode == 0
+    assert out1.stdout == 'one'
+    assert not out1.stderr
 
-    out1 = out[1]
-    assert out1['returncode'] == 0
-    assert out1['stdout'] == 'two three'
-    assert not out1['stderr']
+    out2 = out[1]
+    assert out2.returncode == 0
+    assert out2.stdout == 'two three'
+    assert not out2.stderr
 
 
 def test_cmd_run_has_list_and_run_with_list_save():
@@ -463,24 +468,24 @@ def test_cmd_run_has_list_and_run_with_list_save():
     assert len(out) == 4
 
     out1 = out[0]
-    assert out1['returncode'] == 0
-    assert out1['stdout'] == 'one'
-    assert not out1['stderr']
+    assert out1.returncode == 0
+    assert out1.stdout == 'one'
+    assert not out1.stderr
 
     out2 = out[1]
-    assert out2['returncode'] == 0
-    assert out2['stdout'] == 'two'
-    assert not out2['stderr']
+    assert out2.returncode == 0
+    assert out2.stdout == 'two'
+    assert not out2.stderr
 
     out3 = out[2]
-    assert out3['returncode'] == 0
-    assert out3['stdout'] == 'three'
-    assert not out3['stderr']
+    assert out3.returncode == 0
+    assert out3.stdout == 'three'
+    assert not out3.stderr
 
     out4 = out[3]
-    assert out4['returncode'] == 0
-    assert out4['stdout'] == 'four'
-    assert not out4['stderr']
+    assert out4.returncode == 0
+    assert out4.stdout == 'four'
+    assert not out4.stderr
 
 
 def test_cmd_run_has_list_input_save_dev_null():
@@ -527,9 +532,9 @@ def test_cmd_run_save_with_encoding():
     pypyr.steps.cmd.run_step(context)
 
     out = context['cmdOut']
-    assert out['returncode'] == 0
-    assert out['stdout'] == 'one two three'
-    assert out['stderr'] == 'four'
+    assert out.returncode == 0
+    assert out.stdout == 'one two three'
+    assert out.stderr == 'four'
 
 
 def test_cmd_run_save_with_binary_mode():
@@ -555,8 +560,8 @@ $err=[System.Text.Encoding]::Unicode.GetBytes(\\"two`n\\");
     pypyr.steps.cmd.run_step(context)
 
     out = context['cmdOut']
-    assert out['returncode'] == 0
-    assert out['stdout'].decode('utf-16') == 'one\n'
-    assert out['stderr'].decode('utf-16') == 'two\n'
+    assert out.returncode == 0
+    assert out.stdout.decode('utf-16') == 'one\n'
+    assert out.stderr.decode('utf-16') == 'two\n'
 
 # endregion encoding

--- a/tests/unit/pypyr/steps/cmd_step_test.py
+++ b/tests/unit/pypyr/steps/cmd_step_test.py
@@ -222,6 +222,25 @@ def test_cmd_run_save_with_stdout_or_stderr():
     assert str(err.value) == (
         "You can't set `stdout` or `stderr` when `save` is True.")
 
+
+def test_cmd_error_throws_with_save_true_executable_not_found():
+    """Raise error when can't find the subprocess executable."""
+    cmd = get_cmd('tests/testfiles/cmds/xxx',
+                  r'tests\testfiles\cmds\xxx')
+
+    with pytest.raises(FileNotFoundError) as err:
+        context = Context({'cmd': {'run': cmd, 'save': True}})
+        pypyr.steps.cmd.run_step(context)
+
+    # cmdOut NOT populated because couldn't run subproc at all.
+    assert 'cmdOut' not in context
+
+    # on windows, FileNotFoundError does NOT set filename, instead:
+    # FileNotFoundError(2, 'The system cannot find the file specified',
+    #                   None, 2 None)
+    if not is_windows:
+        err.value.filename == cmd
+
 # region list input
 
 

--- a/tests/unit/pypyr/steps/cmds_test.py
+++ b/tests/unit/pypyr/steps/cmds_test.py
@@ -1,0 +1,22 @@
+"""pypyr.steps.cmd unit tests.
+
+The bulk of the unit tests are in:
+tests/unit/steps/dsl/cmdasync_test.py
+
+For tests involving stdout & stderr set to files, see:
+tests/integration/pypyr/steps/cmds_int_test.py
+"""
+from unittest.mock import patch
+
+from pypyr.context import Context
+import pypyr.steps.cmds
+
+
+def test_cmds_step():
+    """Use the AsyncCmdStep handler to run the step."""
+    with patch('pypyr.steps.cmds.AsyncCmdStep') as mock_runner:
+        pypyr.steps.cmds.run_step(Context({'a': 'b'}))
+
+    mock_runner.assert_called_once_with(name='pypyr.steps.cmds',
+                                        context={'a': 'b'},
+                                        is_shell=False)

--- a/tests/unit/pypyr/steps/dsl/cmd_test.py
+++ b/tests/unit/pypyr/steps/dsl/cmd_test.py
@@ -593,9 +593,9 @@ def test_cmdstep_runstep_cmd_is_dict_save_true_shell_false():
                                      shell=False,
                                      text=True)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert context['cmdOut']['stdout'] == 'std'
-    assert context['cmdOut']['stderr'] == 'err'
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == 'std'
+    assert context['cmdOut'].stderr == 'err'
 
 
 def test_cmdstep_runstep_cmd_is_dict_save_true_shell_true():
@@ -636,9 +636,9 @@ def test_cmdstep_runstep_cmd_is_dict_save_true_shell_true():
                                      shell=True,
                                      text=True)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert context['cmdOut']['stdout'] == 'std'
-    assert context['cmdOut']['stderr'] is None
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == 'std'
+    assert context['cmdOut'].stderr is None
 
 
 def test_cmdstep_runstep_cmd_is_dict_save_true_shell_true_cwd_set():
@@ -683,9 +683,9 @@ def test_cmdstep_runstep_cmd_is_dict_save_true_shell_true_cwd_set():
                                      shell=True,
                                      text=True)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert context['cmdOut']['stdout'] == 'std'
-    assert context['cmdOut']['stderr'] is None
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == 'std'
+    assert context['cmdOut'].stderr is None
 
 
 def test_cmdstep_runstep_cmd_is_dict_save_true_shell_false_formatting():
@@ -733,6 +733,6 @@ def test_cmdstep_runstep_cmd_is_dict_save_true_shell_false_formatting():
                                      shell=False,
                                      text=True)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert context['cmdOut']['stdout'] == 'std'
-    assert context['cmdOut']['stderr'] == 'err'
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == 'std'
+    assert context['cmdOut'].stderr == 'err'

--- a/tests/unit/pypyr/steps/dsl/cmdasync_test.py
+++ b/tests/unit/pypyr/steps/dsl/cmdasync_test.py
@@ -1168,7 +1168,6 @@ def test_dsl_async_cmd_run_has_list_input_save():
 
     out2 = out[1]
     assert out2.returncode == 0
-    print(f"{out2.stdout=}")
     assert out2.stdout == 'two three'
     assert not out2.stderr
 

--- a/tests/unit/pypyr/steps/dsl/cmdasync_test.py
+++ b/tests/unit/pypyr/steps/dsl/cmdasync_test.py
@@ -1,0 +1,1499 @@
+"""pypyr.dsl.cmdasync unit tests."""
+# can remove __future__ once py 3.10 the lowest supported version
+from __future__ import annotations
+import asyncio
+import asyncio.subprocess
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import call, DEFAULT, Mock, mock_open, patch
+
+import pytest
+
+from pypyr.config import config
+from pypyr.context import Context
+from pypyr.errors import (ContextError,
+                          KeyInContextHasNoValueError,
+                          KeyNotInContextError,
+                          MultiError,
+                          SubprocessError)
+from pypyr.steps.dsl.cmdasync import AsyncCmdStep
+from pypyr.aio.subproc import Command
+
+PIPE = asyncio.subprocess.PIPE
+
+cmd_path = Path.cwd().joinpath('tests/testfiles/cmds')
+is_windows = config.is_windows
+is_posixy = not is_windows
+
+
+def get_cmd(posix, win):
+    """Return posix or win depending on current platform."""
+    return win if is_windows else posix
+
+# region validation errors
+
+
+def test_dsl_async_cmd_name_required():
+    """Cmd Step requires name."""
+    with pytest.raises(AssertionError):
+        AsyncCmdStep(None, None)
+
+
+def test_dsl_async_cmd_context_required():
+    """Cmd Step requires context."""
+    with pytest.raises(AssertionError):
+        AsyncCmdStep('blah', None)
+
+
+def test_dsl_async_cmd_context_cmd_required():
+    """Cmd Step requires cmds in context."""
+    with pytest.raises(KeyNotInContextError) as err:
+        AsyncCmdStep('blah', Context({'a': 'b'}))
+
+    assert str(err.value) == ("context['cmds'] doesn't exist. It must exist "
+                              "for blah.")
+
+
+def test_dsl_async_cmd_context_cmd_not_none():
+    """Cmd Step requires cmds in context."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        AsyncCmdStep('blah', Context({'cmds': None}))
+
+    assert str(err.value) == "context['cmds'] must have a value for blah."
+
+
+def test_dsl_async_cmd_context_cmd_not_dict():
+    """Cmd Step requires cmds in context to be a dict if not str."""
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', Context({'cmds': 1}))
+
+    assert str(err.value) == (
+        """\
+blah cmds config should be either a list:
+cmds:
+  - ./my-executable --arg
+  - subdir/executable --arg1
+
+or a dictionary with a `run` sub-key:
+cmds:
+  run:
+    - ./my-executable --arg
+    - subdir/executable --arg1
+  cwd: ./mydir
+
+Any of the list items in root can be in expanded syntax:
+cmds:
+  - ./my-executable --arg
+  - subdir/executable --arg1
+  - run:
+      - ./arb-executable1 --arg value1
+      - [./arb-executable2.1, ./arb-executable2.2]
+    cwd: ../mydir/subdir
+  - [./arb-executable3.1, ./arb-executable3.2]""")
+
+
+def test_dsl_async_cmd_list_must_be_str_or_dict():
+    """Each list input must be a string or a dict."""
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', Context({'cmds': ['cmd1', 123]}))
+
+    assert str(err.value) == ("""\
+123 in blah cmds config is wrong.
+Each list item should be either a simple string, or a list to run in serial,
+or a dict for expanded syntax:
+cmds:
+  - ./my-executable --arg
+  - run:
+      - ./another-executable --arg value
+      - ./another-executable --arg value2
+    cwd: ../mydir/subdir
+  - run:
+      - ./arb-executable1 --arg value1
+      - [./arb-executable2.1, ./arb-executable2.2]
+    cwd: ../mydir/arbdir
+  - [./arb-executable3.1, ./arb-executable3.2]""")
+
+
+def test_dsl_async_cmd_dict_run_must_exist():
+    """Dict input run must exist."""
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', Context({'cmds': {'runs': 'abc'}}))
+
+    # noqa is for line too long
+    assert str(err.value) == ("""\
+cmds.run doesn't exist for blah.
+The input should look like this in expanded syntax:
+cmds:
+  run:
+    - ./my-executable --arg
+    - subdir/executable --arg1
+  cwd: ./mydir
+
+If you're passing in a list of commands, each command should be a simple string,
+or a sub-list of commands to run in serial,
+or a dict with a `run` entry:
+cmds:
+  - ./my-executable --arg
+  - run: ./another-executable --arg value
+    cwd: ../mydir/subdir
+  - run:
+      - ./arb-executable1 --arg value1
+      - [./arb-executable2.1, ./arb-executable2.2]
+    cwd: ../mydir/arbdir
+  - [./arb-executable3.1, ./arb-executable3.2]""")  # noqa: E501
+
+
+def test_dsl_async_cmd_dict_run_must_have_value():
+    """Dict input run must have value."""
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', Context({'cmds': {'run': ''}}))
+
+    assert str(err.value) == ("""\
+cmds.run must have a value for blah.
+The `run` input should look something like this:
+cmds:
+  run:
+    - ./arb-executable1 --arg value1
+    - ./arb-executable2 --arg value2
+  cwd: ../mydir/arbdir""")
+
+
+def test_dsl_async_cmd_must_be_str_or_list():
+    """Input to cmd must be a str or a list."""
+    with pytest.raises(MultiError) as err:
+        cmd = AsyncCmdStep('blah', Context({'cmds': {'run': 123}}))
+        cmd.run_step()
+
+    assert str(err.value) == ("""\
+The following error(s) occurred while running the async commands:
+ContextError: 123 cmds input.
+Each command should be a simple string, or a sub-list to run in serial:
+cmds:
+  - ./my-executable --arg
+  - ./another-executable --arg
+  - [./executableA.1, ./executableA.2]
+
+Or in the expanded syntax, set `run` to a list:
+cmds:
+  run:
+    - ./my-executable --arg
+    - ./another-executable --arg
+    - [./executableA.1, ./executableA.2]
+  cwd: ./mydir""")
+
+
+def test_dsl_async_cmd_run_save_with_stdout_stderr():
+    """Raise err when setting stdout | stderr alongside save."""
+    context = Context({
+        'cmds': {
+            'run': ['A', 'B'],
+            'save': True,
+            'stdout': '/arb1',
+            'stderr': '/arb2'}
+    })
+
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', context)
+
+    assert str(err.value) == (
+        "You can't set `stdout` or `stderr` when `save` is True.")
+
+
+def test_dsl_async_cmd_run_save_with_stdout():
+    """Raise err when setting stdout | stderr alongside save."""
+    context = Context({
+        'cmds': {
+            'run': ['A', 'B'],
+            'save': True,
+            'stdout': '/arb1'}
+    })
+
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', context)
+
+    assert str(err.value) == (
+        "You can't set `stdout` or `stderr` when `save` is True.")
+
+
+def test_dsl_async_run_save_with_stdout_or_stderr():
+    """Raise err when setting stdout | stderr alongside save - or not and."""
+    context = Context({
+        'cmds': {
+            'run': ['A', 'B'],
+            'save': True,
+            'stderr': '/arb2'}
+    })
+
+    with pytest.raises(ContextError) as err:
+        AsyncCmdStep('blah', context)
+
+    assert str(err.value) == (
+        "You can't set `stdout` or `stderr` when `save` is True.")
+
+# endregion validation errors
+
+# region minimal/maximal inputs
+
+
+def test_async_cmd_minimal():
+    """Minimal inputs."""
+    context = Context({'cmds': ['A', 'B']})
+
+    step = AsyncCmdStep('blah', context)
+
+    assert len(step.commands) == 2
+    cmd1 = step.commands[0]
+    assert cmd1.cmd == 'A'
+    assert cmd1.is_shell is False
+    assert cmd1.cwd is None
+    assert cmd1.is_save is False
+    assert cmd1.is_text is False
+    assert cmd1.stdout is None
+    assert cmd1.stderr is None
+    assert cmd1.encoding == config.default_cmd_encoding
+    assert cmd1.append is False
+
+
+def test_async_cmd_minimal_save():
+    """Minimal inputs when save True."""
+    context = Context({'cmds': {'run': ['A', 'B'], 'save': True}})
+
+    step = AsyncCmdStep('blah', context)
+
+    assert len(step.commands) == 1
+    cmd1 = step.commands[0]
+    assert cmd1.cmd == ['A', 'B']
+    assert cmd1.is_shell is False
+    assert cmd1.cwd is None
+    assert cmd1.is_save is True
+    assert cmd1.is_text is True
+    assert cmd1.stdout == PIPE
+    assert cmd1.stderr == PIPE
+    assert cmd1.encoding == config.default_cmd_encoding
+    assert cmd1.append is False
+
+
+def test_async_cmd_maximal_save():
+    """Maximal inputs with save true."""
+    context = Context({'cmds': {
+        'run': ['A', 'B'],
+        'cwd': '/cwd',
+        'save': True,
+        'encoding': 'enc',
+        'bytes': True}})
+
+    step = AsyncCmdStep('blah', context)
+
+    assert len(step.commands) == 1
+    cmd1 = step.commands[0]
+    assert cmd1.cmd == ['A', 'B']
+    assert cmd1.is_shell is False
+    assert cmd1.is_text is False
+    assert cmd1.cwd == '/cwd'
+    assert cmd1.is_save is True
+    assert cmd1.stdout == PIPE
+    assert cmd1.stderr == PIPE
+    assert cmd1.encoding == 'enc'
+    assert cmd1.append is False
+
+
+def test_async_cmd_maximal_not_save():
+    """Maximal inputs with save false."""
+    context = Context({'cmds': {
+        'run': ['A', 'B'],
+        'cwd': '/cwd',
+        'stdout': '/stdout',
+        'stderr': '/stderr',
+        'encoding': 'enc',
+        'bytes': True,
+        'append': True}})
+
+    step = AsyncCmdStep('blah', context)
+
+    assert len(step.commands) == 1
+    cmd1 = step.commands[0]
+    assert cmd1.cmd == ['A', 'B']
+    assert cmd1.is_shell is False
+    assert cmd1.is_text is False
+    assert cmd1.cwd == '/cwd'
+    assert cmd1.is_save is False
+    assert cmd1.stdout == '/stdout'
+    assert cmd1.stderr == '/stderr'
+    assert cmd1.encoding == 'enc'
+    assert cmd1.append is True
+
+
+def test_async_cmd_maximal_save_formatting():
+    """Maximal inputs with save true with formatting expressions."""
+    context = Context({
+        'cmdA': 'A',
+        'cmdB': 'B',
+        'cwd': '/cwd',
+        'save': True,
+        'enc': 'enc',
+        'bytes': True,
+        'cmds': {
+            'run': ['{cmdA}', '{cmdB}'],
+            'cwd': '{cwd}',
+            'save': '{save}',
+            'encoding': '{enc}',
+            'bytes': '{bytes}'}})
+
+    step = AsyncCmdStep('blah', context)
+
+    assert len(step.commands) == 1
+    cmd1 = step.commands[0]
+    assert cmd1.cmd == ['A', 'B']
+    assert cmd1.is_shell is False
+    assert cmd1.is_text is False
+    assert cmd1.cwd == '/cwd'
+    assert cmd1.is_save is True
+    assert cmd1.stdout == PIPE
+    assert cmd1.stderr == PIPE
+    assert cmd1.encoding == 'enc'
+    assert cmd1.append is False
+
+
+def test_async_cmd_maximal_not_save_formatting():
+    """Maximal inputs with save false with formatting expressions."""
+    context = Context({
+        'cmdinput': ['A', 'B'],
+        'cwd': '/cwd',
+        'save': True,
+        'enc': 'enc',
+        'bytes': True,
+        'stdout': '/stdout',
+        'stderr': '/stderr',
+        'append': True,
+        'cmds': {
+            'run': '{cmdinput}',
+            'cwd': '{cwd}',
+            'stdout': '{stdout}',
+            'stderr': '{stderr}',
+            'encoding': '{enc}',
+            'bytes': '{bytes}',
+            'append': '{append}'}})
+
+    step = AsyncCmdStep('blah', context)
+
+    assert len(step.commands) == 1
+    cmd1 = step.commands[0]
+    assert cmd1.cmd == ['A', 'B']
+    assert cmd1.is_shell is False
+    assert cmd1.is_text is False
+    assert cmd1.cwd == '/cwd'
+    assert cmd1.is_save is False
+    assert cmd1.stdout == '/stdout'
+    assert cmd1.stderr == '/stderr'
+    assert cmd1.encoding == 'enc'
+    assert cmd1.append is True
+
+# endregion minimal/maximal inputs
+
+# region test input combos w mocked subprocess call
+
+# region AsyncMock plumbing
+
+
+class AsyncMock(Mock):
+    """Mock that acts like a coroutine/awaitable/future.
+
+    As of py3.8, could use the built-in AsyncMock from unittest. But, still
+    have to cater to py3.7, so stuck with this, yay.
+    """
+
+    async def __call__(self, *args, **kwargs):
+        """Make the mock awaitable."""
+        return super().__call__(*args, **kwargs)
+
+
+def get_async_subproc_future(expected: list[asyncio.subprocess.Process]):
+    """Return awaitable mock with canned responses/results."""
+    return AsyncMock(side_effect=expected)
+
+
+def expected_result(rc, stdout, stderr):
+    """Return a mock of Process with preconfigured output for communicate()."""
+    process = Mock(spec=asyncio.subprocess.Process)
+    process.returncode = rc
+    process.communicate = AsyncMock(return_value=(stdout, stderr))
+    return process
+
+
+ASYNC_SUBPROCESS_EXEC = 'pypyr.aio.subproc.asyncio.create_subprocess_exec'
+ASYNC_SUBPROCESS_SHELL = 'pypyr.aio.subproc.asyncio.create_subprocess_shell'
+
+# endregion AsyncMock plumbing
+
+
+def test_async_cmd_simple_list():
+    """Simple syntax list pass through with split vs no split on shlex."""
+    context = Context({'cmds': ['A', 'B arg1 "arg 2"', 'C']})
+    step = AsyncCmdStep('blah', context)
+
+    assert step.commands.commands == [Command('A'),
+                                      Command('B arg1 "arg 2"'),
+                                      Command('C')]
+
+    fake_subproc = get_async_subproc_future(
+        [expected_result(0, None, None)] * 3)
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=None, stderr=None, cwd=None),
+        call('B', 'arg1', 'arg 2', stdout=None, stderr=None, cwd=None),
+        call('C', stdout=None, stderr=None, cwd=None)])
+
+    assert 'cmdOut' not in context
+
+
+def test_async_cmd_simple_str():
+    """Simple syntax str for single item."""
+    context = Context({'cmds': 'A'})
+    step = AsyncCmdStep('blah', context)
+
+    assert step.commands.commands == [Command('A')]
+
+    fake_subproc = get_async_subproc_future([expected_result(0, None, None)])
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    assert mock_subproc.mock_calls == [
+        call('A', stdout=None, stderr=None, cwd=None)]
+
+    assert 'cmdOut' not in context
+
+
+def test_async_shell_simple_list():
+    """Simple syntax list pass through with split vs no split on shlex."""
+    context = Context({'cmds': ['A', 'B arg1 "arg 2"', 'C']})
+    step = AsyncCmdStep('blah', context, is_shell=True)
+
+    assert step.commands.commands == [Command('A', is_shell=True),
+                                      Command('B arg1 "arg 2"', is_shell=True),
+                                      Command('C', is_shell=True)]
+
+    fake_subproc = get_async_subproc_future(
+        [expected_result(0, None, None)] * 3)
+
+    with patch(ASYNC_SUBPROCESS_SHELL, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=None, stderr=None, cwd=None),
+        call('B arg1 "arg 2"', stdout=None, stderr=None, cwd=None),
+        call('C', stdout=None, stderr=None, cwd=None)])
+
+    assert 'cmdOut' not in context
+
+
+def test_async_list_with_dict():
+    """Simple syntax list with any item a dict."""
+    context = Context({'cmds': [
+        'A',
+        {'run': ['B', 'C']},
+        {'run': ['D', ['E.1', 'E.2'], 'F']},
+        'G']})
+    step = AsyncCmdStep('blah', context)
+
+    assert step.commands.commands == [Command('A'),
+                                      Command(['B', 'C']),
+                                      Command(['D', ['E.1', 'E.2'], 'F']),
+                                      Command('G')]
+
+    fake_subproc = get_async_subproc_future(
+        [expected_result(0, None, None)] * 8)
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    # sadly can't really confirm that the serial calls happened serially here
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=None, stderr=None, cwd=None),
+        call('B', stdout=None, stderr=None, cwd=None),
+        call('C', stdout=None, stderr=None, cwd=None),
+        call('D', stdout=None, stderr=None, cwd=None),
+        call('E.1', stdout=None, stderr=None, cwd=None),
+        call('E.2', stdout=None, stderr=None, cwd=None),
+        call('F', stdout=None, stderr=None, cwd=None),
+        call('G', stdout=None, stderr=None, cwd=None)])
+
+    assert 'cmdOut' not in context
+
+
+def test_async_simple_list_with_serial():
+    """Simple syntax list with sub-list for serial."""
+    context = Context({'cmds': ['A', ['B.1', 'B.2'], ['C.1', 'C.2'], 'D']})
+    step = AsyncCmdStep('blah', context)
+
+    assert step.commands.commands == [Command('A'),
+                                      Command([['B.1', 'B.2']]),
+                                      Command([['C.1', 'C.2']]),
+                                      Command('D')]
+
+    fake_subproc = get_async_subproc_future(
+        [expected_result(0, None, None)] * 6)
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    # sadly can't really confirm that the serial calls happened serially here
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=None, stderr=None, cwd=None),
+        call('D', stdout=None, stderr=None, cwd=None),
+        call('B.1', stdout=None, stderr=None, cwd=None),
+        call('B.2', stdout=None, stderr=None, cwd=None),
+        call('C.1', stdout=None, stderr=None, cwd=None),
+        call('C.2', stdout=None, stderr=None, cwd=None)])
+
+    assert 'cmdOut' not in context
+
+
+def test_async_dict_run_list_with_serial():
+    """Expanded syntax run list with sub-list for serial."""
+    context = Context({'cmds': {'run':
+                                ['A', ['B.1', 'B.2'], ['C.1', 'C.2'], 'D']}})
+    step = AsyncCmdStep('blah', context)
+
+    assert step.commands.commands == [Command(['A',
+                                      ['B.1', 'B.2'],
+                                      ['C.1', 'C.2'],
+                                      'D'
+                                      ])]
+
+    fake_subproc = get_async_subproc_future(
+        [expected_result(0, None, None)] * 6)
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    # sadly can't really confirm that the serial calls happened serially here
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=None, stderr=None, cwd=None),
+        call('D', stdout=None, stderr=None, cwd=None),
+        call('B.1', stdout=None, stderr=None, cwd=None),
+        call('B.2', stdout=None, stderr=None, cwd=None),
+        call('C.1', stdout=None, stderr=None, cwd=None),
+        call('C.2', stdout=None, stderr=None, cwd=None)])
+
+    assert 'cmdOut' not in context
+
+# region save
+
+
+def test_dsl_async_cmd_shell_override():
+    """Override shell arg from dict shell input."""
+    obj = AsyncCmdStep('blahname', Context({'cmds': {'run': 'blah',
+                                                     'cwd': 'pathhere',
+                                                     'shell': True,
+                                                     }}),
+                       is_shell=False)
+
+    assert not obj.is_shell
+    assert obj.logger.name == 'blahname'
+    assert len(obj.commands.commands) == 1
+    cmd = obj.commands.commands[0]
+    assert cmd.is_shell
+    assert not cmd.is_save
+
+
+def test_async_cmd_with_save():
+    """Save with simple list."""
+    context = Context({'cmds': {'run': ['A', '"B with space" --arg', 'C'],
+                                'save': True}})
+    step = AsyncCmdStep('blah', context)
+
+    assert step.commands.commands == [Command(['A',
+                                      '"B with space" --arg',
+                                               'C'], is_save=True)]
+
+    fake_subproc = get_async_subproc_future([
+        expected_result(0, b'out1', b'err1'),
+        expected_result(0, b'out2', b'err2'),
+        expected_result(0, b'out3', b'err3')])
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=PIPE, stderr=PIPE, cwd=None),
+        call('B with space', '--arg', stdout=PIPE, stderr=PIPE, cwd=None),
+        call('C', stdout=PIPE, stderr=PIPE, cwd=None)])
+
+    out1 = context['cmdOut'][0]
+    assert out1.cmd == 'A'
+    assert out1.returncode == 0
+    assert out1.stdout == 'out1'
+    assert out1.stderr == 'err1'
+
+    out2 = context['cmdOut'][1]
+    assert out2.cmd == '"B with space" --arg'
+    assert out2.returncode == 0
+    assert out2.stdout == 'out2'
+    assert out2.stderr == 'err2'
+
+    out3 = context['cmdOut'][2]
+    assert out3.cmd == 'C'
+    assert out3.returncode == 0
+    assert out3.stdout == 'out3'
+    assert out3.stderr == 'err3'
+
+
+def test_async_shell_with_save():
+    """Save with simple list."""
+    context = Context({'cmds': {'run': ['A', '"B with space" --arg', 'C'],
+                                'save': True}})
+    step = AsyncCmdStep('blah', context, is_shell=True)
+
+    assert step.commands.commands == [Command(['A',
+                                      '"B with space" --arg',
+                                               'C'],
+                                              is_shell=True,
+                                              is_save=True)]
+
+    fake_subproc = get_async_subproc_future([
+        expected_result(0, b'out1', b'err1'),
+        expected_result(0, b'out2', b'err2'),
+        expected_result(0, b'out3', b'err3')])
+
+    with patch(ASYNC_SUBPROCESS_SHELL, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    # despite name, checks equality for all items in ANY order
+    TestCase().assertCountEqual(mock_subproc.mock_calls, [
+        call('A', stdout=PIPE, stderr=PIPE, cwd=None),
+        call('"B with space" --arg', stdout=PIPE, stderr=PIPE, cwd=None),
+        call('C', stdout=PIPE, stderr=PIPE, cwd=None)])
+
+    out1 = context['cmdOut'][0]
+    assert out1.cmd == 'A'
+    assert out1.returncode == 0
+    assert out1.stdout == 'out1'
+    assert out1.stderr == 'err1'
+
+    out2 = context['cmdOut'][1]
+    assert out2.cmd == '"B with space" --arg'
+    assert out2.returncode == 0
+    assert out2.stdout == 'out2'
+    assert out2.stderr == 'err2'
+
+    out3 = context['cmdOut'][2]
+    assert out3.cmd == 'C'
+    assert out3.returncode == 0
+    assert out3.stdout == 'out3'
+    assert out3.stderr == 'err3'
+
+
+# endregion save
+
+def test_async_cmds_fail_to_open_file_handle():
+    """Catch error when file handle can't open."""
+    context = Context({
+        'cmds': {
+            'run': ['cmd1', 'cmd2'],
+            'stdout': '/stdout',
+            'stderr': '/stderr'}
+    })
+
+    step = AsyncCmdStep('blah', context)
+
+    with patch('pypyr.aio.subproc.open', mock_open()) as mock_fs:
+        mock_fs.side_effect = [DEFAULT, FileNotFoundError('two')]
+
+        with pytest.raises(MultiError) as err:
+            with patch(ASYNC_SUBPROCESS_EXEC) as mock_subproc:
+                step.run_step()
+
+            mock_subproc.assert_not_called()
+
+        the_err = err.value
+        assert len(the_err) == 1
+        assert str(the_err[0]) == 'two'
+
+    results = step.commands[0].results
+    assert len(results) == 1
+    assert repr(results[0]) == "FileNotFoundError('two')"
+
+
+def test_async_cmds_fail_to_open_file_handle_multiple_files():
+    """Catch error when file handle can't open on multiple expanded."""
+    context = Context({
+        'cmds': [{
+            'run': ['cmd1', 'cmd2'],
+            'stdout': '/stdout',
+            'stderr': '/stderr'},
+            {
+            'run': ['cmd3', 'cmd4'],
+            'stdout': '/stdout2',
+            'stderr': '/stderr2'}
+        ]})
+
+    step = AsyncCmdStep('blah', context)
+
+    with patch('pypyr.aio.subproc.open', mock_open()) as mock_fs:
+        mock_fs.side_effect = [DEFAULT,
+                               FileNotFoundError('two'),
+                               FileNotFoundError('three'),
+                               DEFAULT]
+
+        with pytest.raises(MultiError) as err:
+            with patch(ASYNC_SUBPROCESS_EXEC) as mock_subproc:
+                step.run_step()
+
+            mock_subproc.assert_not_called()
+
+        the_err = err.value
+        assert len(the_err) == 2
+        assert str(the_err[0]) == 'two'
+        assert str(the_err[1]) == 'three'
+
+    assert len(step.commands) == 2
+    results = step.commands[0].results
+    assert len(results) == 1
+    assert repr(results[0]) == "FileNotFoundError('two')"
+
+    results = step.commands[1].results
+    assert len(results) == 1
+    assert repr(results[0]) == "FileNotFoundError('three')"
+
+
+def test_async_cmd_serial_simple_sequence():
+    """Serial happens one after the other."""
+    context = Context({'cmds': ['A', ['B.1', 'B.2'], 'C']})
+
+    step = AsyncCmdStep('blah', context)
+
+    fake_subproc = get_async_subproc_future([
+        expected_result(0, b'outA', b'errA'),
+        expected_result(0, b'outB.1', b'errB.1'),
+        expected_result(0, b'outC', b'errC'),
+        expected_result(0, b'outB.2', b'errB.2'), ])
+
+    with patch(ASYNC_SUBPROCESS_EXEC, fake_subproc) as mock_subproc:
+        step.run_step()
+
+    assert len(mock_subproc.mock_calls) == 4
+    TestCase().assertCountEqual(mock_subproc.mock_calls[:3], [
+        call('A', stdout=None, stderr=None, cwd=None),
+        call('B.1', stdout=None, stderr=None, cwd=None),
+        call('C', stdout=None, stderr=None, cwd=None)
+    ])
+
+    assert mock_subproc.mock_calls[3] == call('B.2',
+                                              stdout=None, stderr=None,
+                                              cwd=None)
+    assert 'cmdOut' not in context
+# endregion test input combos w mocked subprocess call
+
+# region actual subprocess spawning
+
+
+def test_dsl_async_cmd_str_with_spaces_in_path():
+    """Single command string works with spaces in path."""
+    cmd = get_cmd('tests/testfiles/cmds/"file with space.sh"',
+                  r'tests\testfiles\cmds\file with space.bat')
+    context = Context({'a': 'one two',
+                       'd': cmd,
+                      'cmds': '{d} "{a}"'})
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    assert 'cmdOut' not in context
+
+    # and with quotes
+    if is_windows:
+        context = Context({
+            'cmds': r'"tests\testfiles\cmds\file with space.bat" "one two"'})
+        step = AsyncCmdStep('blah', context)
+        step.run_step()
+
+        assert 'cmdOut' not in context
+
+
+def test_dsl_async_cmd_error_throws():
+    """Process returning 1 should throw CalledProcessError with no save."""
+    cmd1 = get_cmd('tests/testfiles/cmds/exit1.sh',
+                   r'tests\testfiles\cmds\exit1.bat')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/exitwitherr.sh',
+                   r'tests\testfiles\cmds\exitwitherr.bat')
+
+    context = Context({'cmds': [cmd1, cmd2]})
+    step = AsyncCmdStep('blah', context)
+
+    with pytest.raises(MultiError) as multi_err:
+        step.run_step()
+
+    assert 'cmdOut' not in context
+
+    errs = multi_err.value
+    assert len(errs) == 2
+
+    err1 = errs[0]
+    assert type(err1) is SubprocessError
+    assert err1.cmd == cmd1
+
+    err2 = errs[1]
+    assert type(err2) is SubprocessError
+    assert err2.cmd == cmd2
+
+
+def test_dsl_async_cmd_error_throws_exception_initiating_spawn():
+    """Exception when can't run the subprocess at all."""
+    cmd1 = get_cmd('tests/testfiles/cmds/xxx1',
+                   r'tests\testfiles\cmds\xxx1')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/xxx2',
+                   r'tests\testfiles\cmds\xxx2')
+
+    cmd3 = get_cmd('tests/testfiles/cmds/exit1.sh',
+                   r'tests\testfiles\cmds\exit1.bat')
+
+    context = Context({'cmds': [cmd1, cmd2, cmd3]})
+    step = AsyncCmdStep('blah', context)
+
+    with pytest.raises(MultiError) as multi_err:
+        step.run_step()
+
+    assert 'cmdOut' not in context
+
+    errs = multi_err.value
+    assert len(errs) == 3
+    err1 = errs[0]
+    assert type(err1) is FileNotFoundError
+    if is_posixy:
+        assert err1.filename == cmd1
+
+    err2 = errs[1]
+    assert type(err2) is FileNotFoundError
+    if is_posixy:
+        assert err2.filename == cmd2
+
+    err3 = errs[2]
+    assert type(err3) is SubprocessError
+    assert err3.returncode == 1
+    assert err3.cmd == cmd3
+
+
+def test_dsl_async_cmd_error_throws_with_save_true():
+    """Process returning 1 should throw CalledProcessError."""
+    cmd = get_cmd('tests/testfiles/cmds/exitwitherr.sh',
+                  r'tests\testfiles\cmds\exitwitherr.bat')
+
+    context = Context({'cmds': {'run': cmd, 'save': True}})
+
+    step = AsyncCmdStep('blah', context)
+
+    with pytest.raises(MultiError):
+        step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 1
+    result = out[0]
+    assert result.returncode == 1
+    assert not result.stdout
+    assert result.stderr == 'arb err here'
+
+
+def test_dsl_async_cmd_error_spawning_throws_with_save_true():
+    """Raise FileNotFoundError when cannot initiate the subprocess."""
+    cmd = get_cmd('tests/testfiles/cmds/xxxx1',
+                  r'tests\testfiles\cmds\xxxx1')
+
+    context = Context({'cmds': {'run': [cmd], 'save': True}})
+
+    step = AsyncCmdStep('blah', context)
+
+    with pytest.raises(MultiError):
+        step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 1
+    result = out[0]
+    assert type(result) is FileNotFoundError
+    if is_posixy:
+        assert result.filename == cmd
+
+
+def test_dsl_async_cmd_run_has_list_input_with_complex_args():
+    """List input to run complex dict works with multiple args."""
+    cmd1 = get_cmd('tests/testfiles/cmds/args.sh',
+                   r'tests\testfiles\cmds\args.bat')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/args2.sh',
+                   r'tests\testfiles\cmds\args2.bat')
+
+    context = Context({'a': 'one',
+                       'b': 'two two',
+                      'c': 'three',
+                       'd': cmd1,
+                       'e': cmd2,
+                       'cmds': {
+                           'run': [
+                               '{d} {a} "{b}" {c}',
+                               '{e} four "five six" seven'],
+                            'save': False}
+                       })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    assert 'cmdOut' not in context
+
+
+def test_dsl_async_cmd_list_input_with_simple_cmd_strings():
+    """List input with command string works with multiple args."""
+    cmd1 = get_cmd('tests/testfiles/cmds/args.sh',
+                   r'tests\testfiles\cmds\args.bat')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/args2.sh',
+                   r'tests\testfiles\cmds\args2.bat')
+
+    context = Context({'a': 'one',
+                       'b': 'two two',
+                      'c': 'three',
+                       'd': cmd1,
+                       'e': cmd2,
+                       'cmds': [
+                           '{d} {a} "{b}" {c}',
+                           '{e} four "five six" seven']})
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    assert 'cmdOut' not in context
+
+
+def test_dsl_async_cmd_list_input_with_complex_args():
+    """List input mixing command string & dict works with multiple args."""
+    cmd1 = get_cmd('tests/testfiles/cmds/args.sh',
+                   r'tests\testfiles\cmds\args.bat')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/args2.sh',
+                   r'tests\testfiles\cmds\args2.bat')
+
+    context = Context({'a': 'one',
+                       'b': 'two two',
+                      'c': 'three',
+                       'd': cmd1,
+                       'e': cmd2,
+                       'cmds': [
+                           {'run': '{d} {a} "{b}" {c}',
+                            'save': False},
+                           '{e} four "five six" seven']})
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    assert 'cmdOut' not in context
+
+
+def test_dsl_async_cmd_list_input_with_simple_cmd_strings_error_on_first():
+    """List input with command string works runs all but raises err on one."""
+    cmd1 = get_cmd('tests/testfiles/cmds/args.sh',
+                   r'tests\testfiles\cmds\args.bat')
+
+    cmd2 = get_cmd('echo blah',
+                   r'tests\testfiles\cmds\echo.bat blah')
+
+    context = Context({'a': 'WRONG VALUE',
+                       'b': 'two two',
+                      'c': 'three',
+                       'd': cmd1,
+                       'e': cmd2,
+                       'cmds': [
+                           '{d} {a} "{b}" {c}',
+                           '{e}']})
+    step = AsyncCmdStep('blah', context)
+
+    with pytest.raises(MultiError) as err:
+        step.run_step()
+
+    assert len(err.value) == 1
+    the_err = err.value[0]
+
+    assert the_err.cmd == f'{cmd1} WRONG VALUE "two two" three'
+
+    assert 'cmdOut' not in context
+    assert len(step.commands) == 2
+    cmd2_results = step.commands[1].results
+    assert len(cmd2_results) == 1
+    assert cmd2_results[0].cmd == cmd2
+    assert cmd2_results[0].returncode == 0
+
+
+def test_dsl_async_cmd_list_input_with_complex_args_error_on_first():
+    """List input mixing command string & dict raises err on one."""
+    cmd1 = get_cmd('tests/testfiles/cmds/args.sh',
+                   r'tests\testfiles\cmds\args.bat')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/args2.sh',
+                   r'tests\testfiles\cmds\args2.bat')
+
+    context = Context({'a': 'WRONG',
+                       'b': 'two two',
+                      'c': 'three',
+                       'd': cmd1,
+                       'e': cmd2,
+                       'cmds': [
+                           {'run': '{d} {a} "{b}" {c}',
+                            'save': False},
+                           '{e} four "five six" seven']})
+
+    step = AsyncCmdStep('blah', context)
+    with pytest.raises(MultiError) as err:
+        step.run_step()
+
+    assert len(err.value) == 1
+    the_err = err.value[0]
+
+    assert the_err.cmd == f'{cmd1} WRONG "two two" three'
+
+    assert 'cmdOut' not in context
+    assert len(step.commands) == 2
+    cmd2_results = step.commands[1].results
+    assert len(cmd2_results) == 1
+    assert cmd2_results[0].cmd == f'{cmd2} four "five six" seven'
+    assert cmd2_results[0].returncode == 0
+
+
+def test_dsl_async_cmd_dict_input_sequence_with_cwd_interpolate():
+    """Cwd plus interpolation."""
+    if is_windows:
+        # windows path supports front slashes IF it's absolute
+        cmd = cmd_path.joinpath('pwd.bat').as_posix()
+    else:
+        # deliberately testing relative path resolution here
+        cmd = 'testfiles/cmds/pwd.sh'
+
+    context = Context({'k1': 'tests',
+                       'cmds': {'run': cmd,
+                                'save': True,
+                                'cwd': '{k1}'}})
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 1
+    result = out[0]
+    assert result.returncode == 0
+    assert Path(result.stdout).samefile('./tests')
+    assert not result.stderr
+# region is_save
+
+
+def test_dsl_async_cmd_list_input_with_complex_args_error_only_first_save():
+    """List input mixing command str & dict, all error but 1st save output."""
+    cmd1 = get_cmd('tests/testfiles/cmds/args.sh',
+                   r'tests\testfiles\cmds\args.bat')
+
+    cmd2 = get_cmd('tests/testfiles/cmds/args2.sh',
+                   r'tests\testfiles\cmds\args2.bat')
+
+    context = Context({'a': 'WRONG',
+                       'b': 'two two',
+                      'c': 'three',
+                       'd': cmd1,
+                       'e': cmd2,
+                       'cmds': [
+                           {'run': '{d} {a} "{b}" {c}',
+                            'save': True},
+                           '{e} WRONG "five six" seven']})
+
+    step = AsyncCmdStep('blah', context)
+
+    with pytest.raises(MultiError) as err:
+        step.run_step()
+
+    assert len(err.value) == 2
+    err1 = err.value[0]
+
+    assert err1.cmd == f'{cmd1} WRONG "two two" three'
+    assert err1.returncode == 1
+    assert err1.stdout == b''
+    assert err1.stderr == 'assert failed'
+
+    err2 = err.value[1]
+
+    # save is only true for 1st one, thus no stdout/stderr
+    assert err2.cmd == f'{cmd2} WRONG "five six" seven'
+    assert err2.returncode == 1
+    assert err2.stdout is None
+    assert err2.stderr is None
+
+    # only the cmd with save True ends up in cmdOut
+    out = context['cmdOut']
+    assert len(out) == 1
+    out1 = out[0]
+    assert out1.cmd == f'{cmd1} WRONG "two two" three'
+    assert out1.returncode == 1
+    assert out1.stdout == b''
+    assert out1.stderr == 'assert failed'
+
+
+def test_dsl_async_cmd_run_has_list_input_save():
+    """List input to run complex dict save all output."""
+    cmd1 = get_cmd('echo one',
+                   r'tests\testfiles\cmds\echo.bat one')
+
+    cmd2 = get_cmd('echo "two three"',
+                   r'tests\testfiles\cmds\echo.bat "two three"')
+
+    context = Context({
+        'cmds': {
+            'run': [cmd1, cmd2],
+            'save': True}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 2
+    out1 = out[0]
+    assert out1.returncode == 0
+    assert out1.stdout == 'one'
+    assert not out1.stderr
+
+    out2 = out[1]
+    assert out2.returncode == 0
+    print(f"{out2.stdout=}")
+    assert out2.stdout == 'two three'
+    assert not out2.stderr
+
+
+def test_dsl_async_cmd_list_with_multiple_runs_save():
+    """List input with run in expanded, everything save to results."""
+    cmd1 = get_cmd('echo one',
+                   r'tests\testfiles\cmds\echo.bat one')
+
+    cmd2 = get_cmd('echo two',
+                   r'tests\testfiles\cmds\echo.bat two')
+
+    cmd3 = get_cmd('echo three',
+                   r'tests\testfiles\cmds\echo.bat three')
+
+    cmd4 = get_cmd('echo four',
+                   r'tests\testfiles\cmds\echo.bat four')
+
+    cmd5 = get_cmd('echo five',
+                   r'tests\testfiles\cmds\echo.bat five')
+
+    context = Context({
+        'cmds': [
+            {'run': [cmd1, cmd2],
+             'save': True},
+            {'run': [cmd3, cmd4],
+             'save': True},
+            cmd5,
+        ]
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 4
+
+    out1 = out[0]
+    assert out1.returncode == 0
+    assert out1.stdout == 'one'
+    assert not out1.stderr
+
+    out2 = out[1]
+    assert out2.returncode == 0
+    assert out2.stdout == 'two'
+    assert not out2.stderr
+
+    out3 = out[2]
+    assert out3.returncode == 0
+    assert out3.stdout == 'three'
+    assert not out3.stderr
+
+    out4 = out[3]
+    assert out4.returncode == 0
+    assert out4.stdout == 'four'
+    assert not out4.stderr
+
+
+def test_dsl_async_cmd_run_has_list_input_save_dev_null():
+    """List input to run complex dict save all output to /dev/null."""
+    cmd1 = get_cmd('echo one',
+                   r'tests\testfiles\cmds\echo.bat one')
+
+    cmd2 = get_cmd('echo two three',
+                   r'tests\testfiles\cmds\echo.bat "two three"')
+
+    context = Context({
+        'cmds': {
+            'run': [cmd1, cmd2],
+            'stdout': '/dev/null',
+            'stderr': '/dev/null'}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    assert 'cmdOut' not in context
+
+# region encoding
+
+
+powershell = "powershell -ExecutionPolicy Bypass -NoLogo -NoProfile"
+
+
+def test_dsl_async_cmd_run_save_with_encoding():
+    """Encoding works."""
+    if is_windows:
+        cmd = f"{powershell} ./tests/testfiles/cmds/bytes-out.ps1"
+        encoding = 'utf-16le'
+    else:
+        cmd = 'tests/testfiles/cmds/bytes-out.sh'
+        encoding = 'utf-16'
+
+    context = Context({
+        'cmds': {
+            'run': [cmd],
+            'save': True,
+            'encoding': encoding}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 1
+
+    result = context['cmdOut'][0]
+    assert result.returncode == 0
+    assert result.stdout == 'one two three'
+    assert result.stderr == 'four'
+
+
+def test_dsl_async_cmd_run_save_with_binary_mode():
+    """Binary mode does not strip lf."""
+    if is_windows:
+        # the literal \ escaping the " is NB
+        ps_cmd = """\
+$out=[System.Text.Encoding]::Unicode.GetBytes(\\"one`n\\");
+[System.Console]::OpenStandardOutput().Write($out, 0, $out.Length);
+$err=[System.Text.Encoding]::Unicode.GetBytes(\\"two`n\\");
+[System.Console]::OpenStandardError().Write($err, 0, $err.Length);"""
+
+        cmd = f'powershell -NoLogo -NoProfile -Command {ps_cmd}'
+    else:
+        cmd = 'tests/testfiles/cmds/bytes-out-lf.sh'
+
+    context = Context({
+        'cmds': {
+            'run': cmd,
+            'save': True,
+            'bytes': True}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 1
+
+    result = context['cmdOut'][0]
+    assert result.returncode == 0
+    assert result.stdout.decode('utf-16') == 'one\n'
+    assert result.stderr.decode('utf-16') == 'two\n'
+# endregion encoding
+
+# region serial
+
+
+def test_dsl_async_cmd_serial_simple_syntax_save():
+    """Serial with concurrent with save."""
+    echo = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat')
+
+    context = Context({
+        'cmds': {
+            'run': [f'{echo} A', [f'{echo} B.1', f'{echo} B.2'], f'{echo} C'],
+            'save': True}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 3
+
+    outA = out[0]
+    assert outA.stdout == 'stdout A'
+    assert outA.stderr == 'stderr A'
+
+    outB = out[1]
+    assert len(outB) == 2
+    outB1 = outB[0]
+    assert outB1.stdout == 'stdout B.1'
+    assert outB1.stderr == 'stderr B.1'
+
+    outB2 = outB[1]
+    assert outB2.stdout == 'stdout B.2'
+    assert outB2.stderr == 'stderr B.2'
+
+    outC = out[2]
+    assert outC.stdout == 'stdout C'
+    assert outC.stderr == 'stderr C'
+
+
+def test_dsl_async_cmd_serial_multiple_expanded_syntax_save():
+    """Serial with concurrent with save."""
+    echo = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat')
+
+    context = Context({
+        'cmds': [{
+            'run': [f'{echo} A', [f'{echo} B.1', f'{echo} B.2'], f'{echo} C'],
+            'save': True},
+            {
+            'run': [[f'{echo} D.1', f'{echo} D.2']],
+            'save': True}
+        ]
+    })
+
+    step = AsyncCmdStep('blah', context)
+    step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 4
+
+    outA = out[0]
+    assert outA.stdout == 'stdout A'
+    assert outA.stderr == 'stderr A'
+
+    outB = out[1]
+    assert len(outB) == 2
+    outB1 = outB[0]
+    assert outB1.stdout == 'stdout B.1'
+    assert outB1.stderr == 'stderr B.1'
+
+    outB2 = outB[1]
+    assert outB2.stdout == 'stdout B.2'
+    assert outB2.stderr == 'stderr B.2'
+
+    outC = out[2]
+    assert outC.stdout == 'stdout C'
+    assert outC.stderr == 'stderr C'
+
+    outD = out[3]
+    assert len(outD) == 2
+    outD1 = outD[0]
+    assert outD1.stdout == 'stdout D.1'
+    assert outD1.stderr == 'stderr D.1'
+
+    outD2 = outD[1]
+    assert outD2.stdout == 'stdout D.2'
+    assert outD2.stderr == 'stderr D.2'
+
+
+def test_dsl_async_cmd_serial_simple_syntax_save_with_error_spawning():
+    """Serial does not continue after error spawning subprocess."""
+    echo = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat')
+
+    cmd_not_found = get_cmd('tests/testfiles/cmds/xxx1',
+                            r'tests\testfiles\cmds\xxx1')
+    context = Context({
+        'cmds': {
+            'run': [f'{echo} A',
+                    [f'{echo} B.1', cmd_not_found, f'{echo} B.3'],
+                    f'{echo} C'],
+            'save': True}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    with pytest.raises(MultiError):
+        step.run_step()
+
+    out = context['cmdOut']
+    assert len(out) == 3
+
+    outA = out[0]
+    assert outA.stdout == 'stdout A'
+    assert outA.stderr == 'stderr A'
+
+    outB = out[1]
+    assert len(outB) == 2
+    outB1 = outB[0]
+    assert outB1.stdout == 'stdout B.1'
+    assert outB1.stderr == 'stderr B.1'
+
+    outB2 = outB[1]
+    assert type(outB2) is FileNotFoundError
+    if is_posixy:
+        assert outB2.filename == cmd_not_found
+
+    outC = out[2]
+    assert outC.stdout == 'stdout C'
+    assert outC.stderr == 'stderr C'
+
+
+def test_dsl_async_cmd_serial_simple_syntax_save_with_error_return_1():
+    """Serial does not continue after subprocess return code is 1."""
+    echo = get_cmd('tests/testfiles/cmds/echo-out-and-err.sh',
+                   r'tests\testfiles\cmds\echo-out-and-err.bat')
+
+    cmd_return_1 = get_cmd('tests/testfiles/cmds/exitwitherr.sh',
+                           r'tests\testfiles\cmds\exitwitherr.bat')
+
+    context = Context({
+        'cmds': {
+            'run': [f'{echo} A',
+                    [f'{echo} B.1', cmd_return_1, f'{echo} B.3'],
+                    f'{echo} C'],
+            'save': True}
+    })
+
+    step = AsyncCmdStep('blah', context)
+    with pytest.raises(MultiError) as err:
+        step.run_step()
+
+    assert len(err.value) == 1
+    the_err = err.value[0]
+    assert the_err.cmd == cmd_return_1
+    assert the_err.stderr == 'arb err here'
+
+    out = context['cmdOut']
+    assert len(out) == 3
+
+    outA = out[0]
+    assert outA.stdout == 'stdout A'
+    assert outA.stderr == 'stderr A'
+
+    outB = out[1]
+    assert len(outB) == 2
+    outB1 = outB[0]
+    assert outB1.stdout == 'stdout B.1'
+    assert outB1.stderr == 'stderr B.1'
+
+    outB2 = outB[1]
+    assert outB2.returncode == 1
+    assert outB2.cmd == cmd_return_1
+    assert not outB2.stdout
+    assert outB2.stderr == 'arb err here'
+
+    outC = out[2]
+    assert outC.stdout == 'stdout C'
+    assert outC.stderr == 'stderr C'
+# endregion serial
+
+# endregion is_save
+
+# endregion actual subprocess spawning

--- a/tests/unit/pypyr/steps/shell_test.py
+++ b/tests/unit/pypyr/steps/shell_test.py
@@ -53,10 +53,10 @@ def test_shell_sequence_with_ampersands_save_output():
                        })
     pypyr.steps.shell.run_step(context)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert context['cmdOut']['stdout'] == ('1 \n2 \n3' if is_windows
-                                           else '1\n2\n3')
-    assert not context['cmdOut']['stderr']
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == ('1 \n2 \n3' if is_windows
+                                        else '1\n2\n3')
+    assert not context['cmdOut'].stderr
 
 
 def test_shell_dict_input_with_string_interpolation_save_out():
@@ -65,9 +65,9 @@ def test_shell_dict_input_with_string_interpolation_save_out():
                                'save': True}})
     pypyr.steps.shell.run_step(context)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert context['cmdOut']['stdout'] == 'blah'
-    assert not context['cmdOut']['stderr']
+    assert context['cmdOut'].returncode == 0
+    assert context['cmdOut'].stdout == 'blah'
+    assert not context['cmdOut'].stderr
 
 
 def test_shell_with_cwd():
@@ -78,9 +78,9 @@ def test_shell_with_cwd():
                                'cwd': 'tests'}})
     pypyr.steps.shell.run_step(context)
 
-    assert context['cmdOut']['returncode'] == 0
-    assert Path(context['cmdOut']['stdout']).samefile('tests')
-    assert not context['cmdOut']['stderr']
+    assert context['cmdOut'].returncode == 0
+    assert Path(context['cmdOut'].stdout).samefile('tests')
+    assert not context['cmdOut'].stderr
 
 
 def test_shell_error_throws():

--- a/tests/unit/pypyr/steps/shells_test.py
+++ b/tests/unit/pypyr/steps/shells_test.py
@@ -1,0 +1,112 @@
+"""pypyr.steps.shells unit tests.
+
+The bulk of the unit tests are in:
+tests/unit/steps/dsl/cmdasync_test.py
+
+For tests involving stdout & stderr set to files, see:
+tests/integration/pypyr/steps/cmds_int_test.py
+"""
+from pathlib import Path
+
+import pytest
+
+from pypyr.config import config
+from pypyr.context import Context
+from pypyr.errors import KeyNotInContextError, MultiError, SubprocessError
+import pypyr.steps.shells
+
+cmd_path = Path.cwd().joinpath('tests/testfiles/cmds')
+is_windows = config.is_windows
+
+
+def get_cmd(posix, win):
+    """Return posix or win depending on current platform."""
+    return win if is_windows else posix
+
+
+def test_shells_str_with_args():
+    """Single shell string works with string interpolation."""
+    cmd = get_cmd('tests/testfiles/cmds/args.sh',
+                  r'tests\testfiles\cmds\args.bat')
+    context = Context({'a': 'one',
+                       'b': 'two two',
+                       'c': 'three',
+                       'd': cmd,
+                       'cmds': ['{d} {a} "{b}" {c}']})
+    pypyr.steps.shells.run_step(context)
+
+    assert 'cmdOut' not in context
+
+
+def test_shells_sequence_with_ampersands_save_output():
+    """Single shell command string with ampersands works."""
+    context = Context({'one': 1,
+                       'two': 2,
+                       'three': 3,
+                       'cmds': {
+                           'run': ['echo {one} && echo {two} && echo {three}'],
+                           'save': True}
+                       })
+    pypyr.steps.shells.run_step(context)
+
+    out = context['cmdOut']
+    assert len(out) == 1
+    out1 = out[0]
+    assert out1.returncode == 0
+    assert out1.stdout == ('1 \r\n2 \r\n3' if is_windows
+                           else '1\n2\n3')
+    assert not out1.stderr
+
+
+def test_shells_dict_input_with_string_interpolation_save_out():
+    """Single command string works with string interpolation."""
+    context = Context({'cmds': {'run': ["echo blah"],
+                                'save': True}})
+    pypyr.steps.shells.run_step(context)
+
+    out = context['cmdOut']
+    assert len(out) == 1
+    out1 = out[0]
+
+    assert out1.returncode == 0
+    assert out1.stdout == 'blah'
+    assert not out1.stderr
+
+
+def test_shells_with_cwd():
+    """Single command string works with string interpolation."""
+    cmd = get_cmd('pwd', 'echo %cd%')
+    context = Context({'cmds': {'run': cmd,
+                                'save': True,
+                                'cwd': 'tests'}})
+    pypyr.steps.shells.run_step(context)
+
+    out = context['cmdOut']
+    assert len(out) == 1
+    out1 = out[0]
+
+    assert out1.returncode == 0
+    assert Path(out1.stdout).samefile('tests')
+    assert not out1.stderr
+
+
+def test_shells_error_throws():
+    """Shell process returning 1 should throw CalledProcessError."""
+    with pytest.raises(MultiError) as the_err:
+        context = Context({'cmds': 'exit 1'})
+        pypyr.steps.shells.run_step(context)
+
+    err = the_err.value
+    assert len(err) == 1
+    assert isinstance(err[0], SubprocessError)
+
+
+def test_shells_empty_context_cmd_throw():
+    """Empty cmds in context should throw assert error."""
+    with pytest.raises(KeyNotInContextError) as err_info:
+        context = Context({'blah': 'blah blah'})
+        pypyr.steps.shells.run_step(context)
+
+    assert str(err_info.value) == ("context['cmds'] "
+                                   "doesn't exist. It must exist for "
+                                   "pypyr.steps.shells.")

--- a/tests/unit/pypyr/subproc_test.py
+++ b/tests/unit/pypyr/subproc_test.py
@@ -3,8 +3,10 @@ import subprocess
 
 import pytest
 
-from pypyr.errors import ContextError
-from pypyr.subproc import Command
+from pypyr.context import Context
+from pypyr.dsl import PyString
+from pypyr.errors import ContextError, SubprocessError
+from pypyr.subproc import Command, SubprocessResult
 
 # region Command
 
@@ -154,3 +156,145 @@ def test_subproc_command_output_handles_dev_null():
         assert stdout == subprocess.DEVNULL
         assert stderr == subprocess.STDOUT
 # endregion Command
+
+# region SubprocessResult
+
+
+def test_subprocessresult_check_returncode_zero():
+    """Return None when returncode is 0."""
+    sr = SubprocessResult('mycmd', 0, stdout='out', stderr='err')
+    assert sr.check_returncode() is None
+
+
+def test_subprocessresult_check_returncode_nonzero():
+    """Return SubprocessError when returncode is non-zero."""
+    sr = SubprocessResult('mycmd', 1, stdout='out', stderr='err')
+    err = sr.check_returncode()
+    assert type(err) is SubprocessError
+    assert err.cmd == 'mycmd'
+    assert err.returncode == 1
+    assert err.stdout == 'out'
+    assert err.stderr == 'err'
+
+    sr = SubprocessResult('mycmd', -1, stdout='out', stderr='err')
+    err = sr.check_returncode()
+    assert type(err) is SubprocessError
+    assert err.cmd == 'mycmd'
+    assert err.returncode == -1
+    assert err.stdout == 'out'
+    assert err.stderr == 'err'
+
+    sr = SubprocessResult('mycmd', -1)
+    err = sr.check_returncode()
+    assert type(err) is SubprocessError
+    assert err.cmd == 'mycmd'
+    assert err.returncode == -1
+    assert err.stdout is None
+    assert err.stderr is None
+
+
+def test_subprocessresult_dict():
+    """Get items like dict from SubprocessResult. For backwards compat."""
+    sr = SubprocessResult('mycmd', 123, stdout='out', stderr='err')
+    assert sr['cmd'] == 'mycmd'
+    assert sr['returncode'] == 123
+    assert sr['stdout'] == 'out'
+    assert sr['stderr'] == 'err'
+
+    # works as a formatting expression
+    context = Context({'cmdOut': sr})
+    out_str = context.get_formatted_value(
+        'begin {cmdOut.returncode} {cmdOut.stdout} {cmdOut.stderr} end')
+    assert out_str == 'begin 123 out err end'
+
+    out_str = context.get_formatted_value(
+        'begin {cmdOut[returncode]} {cmdOut[stdout]} {cmdOut[stderr]} end')
+    assert out_str == 'begin 123 out err end'
+
+    # works in a PyString
+    assert context.get_formatted_value(PyString("cmdOut.returncode")) == 123
+    assert context.get_formatted_value(PyString("cmdOut['returncode']")) == 123
+
+
+def test_subprocessresult_repr():
+    """Convert between SubprocessResult repr and instance."""
+    sr = repr(SubprocessResult('mycmd', 123))
+    rehydrated = eval(sr)
+    assert rehydrated.cmd == 'mycmd'
+    assert rehydrated.returncode == 123
+    assert rehydrated.stdout is None
+    assert rehydrated.stderr is None
+
+    sr = repr(SubprocessResult('mycmd', 123, stdout=b'stdout'))
+    rehydrated = eval(sr)
+    assert rehydrated.cmd == 'mycmd'
+    assert rehydrated.returncode == 123
+    assert rehydrated.stdout == b'stdout'
+    assert rehydrated.stderr is None
+
+    sr = repr(SubprocessResult('mycmd', 123, stderr='err'))
+    rehydrated = eval(sr)
+    assert rehydrated.cmd == 'mycmd'
+    assert rehydrated.returncode == 123
+    assert rehydrated.stdout is None
+    assert rehydrated.stderr == 'err'
+
+    sr = repr(SubprocessResult('mycmd', 123, stdout='out', stderr='err'))
+    rehydrated = eval(sr)
+    assert rehydrated.cmd == 'mycmd'
+    assert rehydrated.returncode == 123
+    assert rehydrated.stdout == 'out'
+    assert rehydrated.stderr == 'err'
+
+    sr = repr(SubprocessResult(['my', 'cmd'], -123,
+                               stdout=b'out', stderr=b'err'))
+    rehydrated = eval(sr)
+    assert rehydrated.cmd == ['my', 'cmd']
+    assert rehydrated.returncode == -123
+    assert rehydrated.stdout == b'out'
+    assert rehydrated.stderr == b'err'
+
+
+def test_subprocessresult_str():
+    """Convert SubprocessResult to friendly string."""
+    sr = str(SubprocessResult('mycmd', 123))
+    assert sr == """\
+cmd: mycmd
+returncode: 123
+stdout: None
+stderr: None
+"""
+
+    sr = str(SubprocessResult('mycmd', 123, stdout=b'out'))
+    assert sr == """\
+cmd: mycmd
+returncode: 123
+stdout: b'out'
+stderr: None
+"""
+
+    sr = str(SubprocessResult('mycmd', 123, stderr=b'err'))
+    assert sr == """\
+cmd: mycmd
+returncode: 123
+stdout: None
+stderr: b'err'
+"""
+
+    sr = str(SubprocessResult('mycmd', 123, stdout=b'out', stderr='err'))
+    assert sr == """\
+cmd: mycmd
+returncode: 123
+stdout: b'out'
+stderr: err
+"""
+
+    sr = str(SubprocessResult(['my', 'cmd'], -123,
+                              stdout='out', stderr='err'))
+    assert sr == """\
+cmd: ['my', 'cmd']
+returncode: -123
+stdout: out
+stderr: err
+"""
+# endregion SubprocessResult

--- a/tests/unit/pypyr/subproc_test.py
+++ b/tests/unit/pypyr/subproc_test.py
@@ -104,21 +104,21 @@ def test_subproc_command_eq():
 
 def test_subproc_command_no_stdout_on_save():
     """Raise when combining stdout/stdour with save."""
-    #  stdin
+    #  stdout
     with pytest.raises(ContextError) as err:
         Command('arb', is_save=True, stdout='in')
 
     assert str(err.value) == (
         "You can't set `stdout` or `stderr` when `save` is True.")
 
-    #  stdout
+    #  stderr
     with pytest.raises(ContextError) as err:
         Command('arb', is_save=True, stderr='out')
 
     assert str(err.value) == (
         "You can't set `stdout` or `stderr` when `save` is True.")
 
-    #  stdin + stdout
+    #  stdout + stdout
     with pytest.raises(ContextError) as err:
         Command('arb', is_save=True, stdout='in', stderr='out')
 
@@ -184,11 +184,11 @@ def test_subprocessresult_check_returncode_nonzero():
     assert err.stdout == 'out'
     assert err.stderr == 'err'
 
-    sr = SubprocessResult('mycmd', -1)
+    sr = SubprocessResult('mycmd', 2)
     err = sr.check_returncode()
     assert type(err) is SubprocessError
     assert err.cmd == 'mycmd'
-    assert err.returncode == -1
+    assert err.returncode == 2
     assert err.stdout is None
     assert err.stderr is None
 


### PR DESCRIPTION
- Run commands/shells concurrently as a subprocess
  - Implemented with asyncio
  - New `pypyr.steps.cmds` and `pypyr.steps.shells` steps are asynchronous analogues of existing `pypyr.steps.cmd` and `pypyr.steps.shell` steps
  - Async cmd encoding configurable with new `config.default_cmd_encoding`
  - closes #273  
- `cmdOut` for `pypyr.steps.cmd` & `pypyr.steps.shell` gets dotted attribute access.
  - instead of `cmdOut[returncode]` access value like this: `cmdOut.returncode`
  - backwards compatible - the old-style dict-like accessors will still work.
  - closes #272 