### PR TITLE
release 5.5 & default_cmd_encoding for serial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.mypy_cache/
 
 # Translations
 *.mo

--- a/pypyr/aio/subproc.py
+++ b/pypyr/aio/subproc.py
@@ -5,6 +5,7 @@ import asyncio
 from asyncio import subprocess
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+import locale
 import logging
 from pathlib import Path
 import shlex
@@ -17,6 +18,10 @@ logger = logging.getLogger(__name__)
 
 # region windows shlex
 is_windows = config.is_windows
+
+DEFAULT_ENCODING = (config.default_cmd_encoding
+                    if config.default_cmd_encoding
+                    else locale.getpreferredencoding(False))
 
 # this code is in fact covered when run on windows (during CI)
 # set no cover so no complaining from coverage on posix
@@ -108,7 +113,7 @@ class Command:
         else:
             self.stdout = stdout
             self.stderr = stderr
-        self.encoding = encoding if encoding else config.default_cmd_encoding
+        self.encoding = encoding if encoding else DEFAULT_ENCODING
         self.append = append
 
         self._results: list[SubprocessResult | Exception | list] = []

--- a/pypyr/aio/subproc.py
+++ b/pypyr/aio/subproc.py
@@ -365,10 +365,10 @@ class Command:
                                                          stderr=stderr,
                                                          cwd=self.cwd)
         else:
-            args = shlexer(cmd)  # type: ignore
-            logger.debug("arg split is: %s", args)
-            proc = await asyncio.create_subprocess_exec(args[0],
-                                                        *args[1:],
+            cmd = shlexer(cmd)  # type: ignore
+            logger.debug("arg split is: %s", cmd)
+            proc = await asyncio.create_subprocess_exec(cmd[0],
+                                                        *cmd[1:],
                                                         stdout=stdout,
                                                         stderr=stderr,
                                                         cwd=self.cwd)

--- a/pypyr/config.py
+++ b/pypyr/config.py
@@ -7,7 +7,6 @@ Attributes:
 from __future__ import annotations
 from collections.abc import Mapping
 from io import StringIO
-import locale
 import os
 from pathlib import Path
 import sys
@@ -118,8 +117,8 @@ class Config():
         # defaults
         self.default_backoff = 'fixed'
         # 'utf-8' is a magic string specially optimized in CPython
-        self.default_cmd_encoding: str | None = os.getenv(
-            'PYPYR_CMD_ENCODING', locale.getpreferredencoding(False))
+        self.default_cmd_encoding: str | None = os.getenv('PYPYR_CMD_ENCODING',
+                                                          None)
         self.default_encoding: str | None = os.getenv('PYPYR_ENCODING', None)
         self.default_loader = 'pypyr.loaders.file'
         self.default_group = 'steps'

--- a/pypyr/subproc.py
+++ b/pypyr/subproc.py
@@ -66,7 +66,7 @@ class Command:
                     "You can't set `stdout` or `stderr` when `save` is True.")
         self.stdout = stdout
         self.stderr = stderr
-        self.encoding = encoding
+        self.encoding = encoding if encoding else config.default_cmd_encoding
         self.append = append
 
         self.results: list[SubprocessResult] = []

--- a/pypyr/version.py
+++ b/pypyr/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '5.4.0'
+__version__ = '5.5.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.4.0
+current_version = 5.5.0
 
 [bumpversion:file:pypyr/version.py]
 

--- a/tests/integration/pypyr/steps/cmds_int_test.py
+++ b/tests/integration/pypyr/steps/cmds_int_test.py
@@ -11,7 +11,7 @@ import pytest
 
 from pypyr.config import config
 from pypyr.context import Context
-from pypyr.errors import MultiError
+from pypyr.errors import MultiError, SubprocessError
 import pypyr.steps.cmds
 
 is_windows = config.is_windows
@@ -55,9 +55,12 @@ def test_async_cmds_stderr_to_stdout(temp_dir):
     assert 'cmdOut' not in context
     err = ex.value
     assert len(err) == 1
-    assert str(err) == f"""\
-The following error(s) occurred while running the async commands:
-SubprocessError: Command '{cmd2}' returned non-zero exit status 1."""
+    the_err = err[0]
+    assert type(the_err) is SubprocessError
+    assert the_err.cmd == [cmd2]
+    assert the_err.returncode == 1
+    # None because save is False
+    assert the_err.stderr is None
 
     out_file_lines = stdout.read_text().rstrip().split('\n')
     TestCase().assertCountEqual(out_file_lines,

--- a/tests/unit/pypyr/aio/aio_subproc_test.py
+++ b/tests/unit/pypyr/aio/aio_subproc_test.py
@@ -1,9 +1,9 @@
 """Unit tests for pypyr.aio.subproc."""
 import asyncio.subprocess as subprocess
+import locale
 
 import pytest
 
-from pypyr.config import config
 from pypyr.errors import ContextError
 from pypyr.aio.subproc import Command, Commands
 
@@ -22,7 +22,7 @@ def test_async_subproc_minimal():
     assert cmd.is_text is False
     assert cmd.stdout is None
     assert cmd.stderr is None
-    assert cmd.encoding == config.default_cmd_encoding
+    assert cmd.encoding == locale.getpreferredencoding(False)
     assert cmd.append is False
     assert cmd.results == []
 

--- a/tests/unit/pypyr/config_test.py
+++ b/tests/unit/pypyr/config_test.py
@@ -1,5 +1,4 @@
 """Unit tests for pypyr/config.py."""
-import locale
 from pathlib import Path
 import sys
 from unittest.mock import call, mock_open, patch
@@ -15,7 +14,6 @@ current_platform = sys.platform
 is_macos: bool = current_platform == 'darwin'
 is_windows: bool = current_platform == 'win32'
 is_posix: bool = not (is_macos or is_windows)
-locale_encoding = locale.getpreferredencoding(False)
 
 
 @pytest.fixture
@@ -56,7 +54,7 @@ def test_config_defaults(no_envs):
         '%(asctime)s %(levelname)s:%(name)s:%(funcName)s: %(message)s')
 
     assert config.default_backoff == 'fixed'
-    assert config.default_cmd_encoding == locale_encoding
+    assert config.default_cmd_encoding is None
     assert config.default_encoding is None
     assert config.default_loader == 'pypyr.loaders.file'
     assert config.default_group == 'steps'
@@ -727,7 +725,7 @@ def test_config_default_str(no_envs):
     assert str(config) == f"""WRITEABLE PROPERTIES:
 
 default_backoff: fixed
-default_cmd_encoding: {locale_encoding}
+default_cmd_encoding:
 default_encoding:
 default_failure_group: on_failure
 default_group: steps
@@ -815,7 +813,7 @@ def test_config_all_str(mock_get_platform, no_envs):
     assert str(config) == f"""WRITEABLE PROPERTIES:
 
 default_backoff: fixed
-default_cmd_encoding: {locale_encoding}
+default_cmd_encoding:
 default_encoding:
 default_failure_group: on_failure
 default_group: steps

--- a/tests/unit/pypyr/steps/dsl/cmdasync_test.py
+++ b/tests/unit/pypyr/steps/dsl/cmdasync_test.py
@@ -630,19 +630,19 @@ def test_async_cmd_with_save():
         call('C', stdout=PIPE, stderr=PIPE, cwd=None)])
 
     out1 = context['cmdOut'][0]
-    assert out1.cmd == 'A'
+    assert out1.cmd == ['A']
     assert out1.returncode == 0
     assert out1.stdout == 'out1'
     assert out1.stderr == 'err1'
 
     out2 = context['cmdOut'][1]
-    assert out2.cmd == '"B with space" --arg'
+    assert out2.cmd == ['B with space', '--arg']
     assert out2.returncode == 0
     assert out2.stdout == 'out2'
     assert out2.stderr == 'err2'
 
     out3 = context['cmdOut'][2]
-    assert out3.cmd == 'C'
+    assert out3.cmd == ['C']
     assert out3.returncode == 0
     assert out3.stdout == 'out3'
     assert out3.stderr == 'err3'
@@ -841,11 +841,11 @@ def test_dsl_async_cmd_error_throws():
 
     err1 = errs[0]
     assert type(err1) is SubprocessError
-    assert err1.cmd == cmd1
+    assert err1.cmd == [cmd1]
 
     err2 = errs[1]
     assert type(err2) is SubprocessError
-    assert err2.cmd == cmd2
+    assert err2.cmd == [cmd2]
 
 
 def test_dsl_async_cmd_error_throws_exception_initiating_spawn():
@@ -882,7 +882,7 @@ def test_dsl_async_cmd_error_throws_exception_initiating_spawn():
     err3 = errs[2]
     assert type(err3) is SubprocessError
     assert err3.returncode == 1
-    assert err3.cmd == cmd3
+    assert err3.cmd == [cmd3]
 
 
 def test_dsl_async_cmd_error_throws_with_save_true():
@@ -1022,13 +1022,13 @@ def test_dsl_async_cmd_list_input_with_simple_cmd_strings_error_on_first():
     assert len(err.value) == 1
     the_err = err.value[0]
 
-    assert the_err.cmd == f'{cmd1} WRONG VALUE "two two" three'
+    assert the_err.cmd == [cmd1, 'WRONG', 'VALUE', 'two two', 'three']
 
     assert 'cmdOut' not in context
     assert len(step.commands) == 2
     cmd2_results = step.commands[1].results
     assert len(cmd2_results) == 1
-    assert cmd2_results[0].cmd == cmd2
+    assert cmd2_results[0].cmd == cmd2.split()
     assert cmd2_results[0].returncode == 0
 
 
@@ -1057,13 +1057,13 @@ def test_dsl_async_cmd_list_input_with_complex_args_error_on_first():
     assert len(err.value) == 1
     the_err = err.value[0]
 
-    assert the_err.cmd == f'{cmd1} WRONG "two two" three'
+    assert the_err.cmd == [cmd1, 'WRONG', 'two two', 'three']
 
     assert 'cmdOut' not in context
     assert len(step.commands) == 2
     cmd2_results = step.commands[1].results
     assert len(cmd2_results) == 1
-    assert cmd2_results[0].cmd == f'{cmd2} four "five six" seven'
+    assert cmd2_results[0].cmd == [cmd2, 'four', 'five six', 'seven']
     assert cmd2_results[0].returncode == 0
 
 
@@ -1119,7 +1119,7 @@ def test_dsl_async_cmd_list_input_with_complex_args_error_only_first_save():
     assert len(err.value) == 2
     err1 = err.value[0]
 
-    assert err1.cmd == f'{cmd1} WRONG "two two" three'
+    assert err1.cmd == [cmd1, 'WRONG', 'two two', 'three']
     assert err1.returncode == 1
     assert err1.stdout == b''
     assert err1.stderr == 'assert failed'
@@ -1127,7 +1127,7 @@ def test_dsl_async_cmd_list_input_with_complex_args_error_only_first_save():
     err2 = err.value[1]
 
     # save is only true for 1st one, thus no stdout/stderr
-    assert err2.cmd == f'{cmd2} WRONG "five six" seven'
+    assert err2.cmd == [cmd2, 'WRONG', 'five six', 'seven']
     assert err2.returncode == 1
     assert err2.stdout is None
     assert err2.stderr is None
@@ -1136,7 +1136,7 @@ def test_dsl_async_cmd_list_input_with_complex_args_error_only_first_save():
     out = context['cmdOut']
     assert len(out) == 1
     out1 = out[0]
-    assert out1.cmd == f'{cmd1} WRONG "two two" three'
+    assert out1.cmd == [cmd1, 'WRONG', 'two two', 'three']
     assert out1.returncode == 1
     assert out1.stdout == b''
     assert out1.stderr == 'assert failed'
@@ -1466,7 +1466,7 @@ def test_dsl_async_cmd_serial_simple_syntax_save_with_error_return_1():
 
     assert len(err.value) == 1
     the_err = err.value[0]
-    assert the_err.cmd == cmd_return_1
+    assert the_err.cmd == [cmd_return_1]
     assert the_err.stderr == 'arb err here'
 
     out = context['cmdOut']
@@ -1484,7 +1484,7 @@ def test_dsl_async_cmd_serial_simple_syntax_save_with_error_return_1():
 
     outB2 = outB[1]
     assert outB2.returncode == 1
-    assert outB2.cmd == cmd_return_1
+    assert outB2.cmd == [cmd_return_1]
     assert not outB2.stdout
     assert outB2.stderr == 'arb err here'
 

--- a/tests/unit/pypyr/steps/dsl/cmdasync_test.py
+++ b/tests/unit/pypyr/steps/dsl/cmdasync_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import asyncio
 import asyncio.subprocess
+import locale
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import call, DEFAULT, Mock, mock_open, patch
@@ -20,6 +21,7 @@ from pypyr.steps.dsl.cmdasync import AsyncCmdStep
 from pypyr.aio.subproc import Command
 
 PIPE = asyncio.subprocess.PIPE
+LOCALE_ENCODING = locale.getpreferredencoding(False)
 
 cmd_path = Path.cwd().joinpath('tests/testfiles/cmds')
 is_windows = config.is_windows
@@ -250,7 +252,7 @@ def test_async_cmd_minimal():
     assert cmd1.is_text is False
     assert cmd1.stdout is None
     assert cmd1.stderr is None
-    assert cmd1.encoding == config.default_cmd_encoding
+    assert cmd1.encoding == LOCALE_ENCODING
     assert cmd1.append is False
 
 
@@ -269,7 +271,7 @@ def test_async_cmd_minimal_save():
     assert cmd1.is_text is True
     assert cmd1.stdout == PIPE
     assert cmd1.stderr == PIPE
-    assert cmd1.encoding == config.default_cmd_encoding
+    assert cmd1.encoding == LOCALE_ENCODING
     assert cmd1.append is False
 
 


### PR DESCRIPTION
- `SubprocessResult` saves shlexed args split, rather than original input command string.
  - This assists pipeline operator debugging/troubleshooting, to see easily if there were any surprises with whitespace/special char escaping on the cmd input string.
  - No backwards compatibility issue, since `SubprocessResult` code as is has not released yet.
- Apply `config.DEFAULT_CMD_ENCODING` to serial cmd/shell too. Previously it only applied to async cmds/shells.
- version bump for minor release. This will release the new async cmds/shells functionality.

Housekeeping:
- exclude mypy cache from gitignore.