### PR TITLE
flake8 new version line length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ shippable/
 
 # ephemeral test output files
 tests/testfiles/out
+
+.vscode/

--- a/pypyr/steps/dsl/fileinoutrewriter.py
+++ b/pypyr/steps/dsl/fileinoutrewriter.py
@@ -195,7 +195,7 @@ class StreamReplacePairsRewriterStep(FileInRewriterStep):
 
         """
         def function_iter_replace_strings(iterable_strings):
-            """Yield a formatted string from iterable_strings using a generator.
+            """Yield a formatted string from iterable_strings using generator.
 
             Args:
                 iterable_strings: Iterable containing strings. E.g a file-like


### PR DESCRIPTION
No functional change.

- new version of flake8 has a problem with the line length here - used to be fine. Rather than argue about it, easier just to amend the line
- exclude .vscode dir in gitignore