### PR TITLE
switch

### DIFF
--- a/pypyr/steps/dsl/cof.py
+++ b/pypyr/steps/dsl/cof.py
@@ -1,43 +1,26 @@
 """pypyr step yaml definition for control of flow instructions."""
+from __future__ import annotations
 import logging
-from pypyr.errors import (ContextError,
+from collections.abc import Mapping
+
+from pypyr.context import Context
+from pypyr.errors import (Call,
+                          ContextError,
+                          ControlOfFlowInstruction,
                           KeyInContextHasNoValueError,
                           KeyNotInContextError)
 
+SWITCH_KEY = 'switch'
 
-def control_of_flow_instruction(name, instruction_type, context, context_key):
-    """Run a control of flow instruction.
+sentinel = object()
 
-    The step config in the context dict looks like this:
-        <<instruction-name>>: <<cmd string>>. Mandatory.
 
-        OR, as a dict
-        <<instruction-name:
-            groups: <<str>> or <<list of str>> - mandatory.
-            success: <<str>>
-            failure: <<str>>
-
-    Args:
-        name: Unique name for step. Likely __name__ of calling step.
-        instruction_type: Type - must inherit from
-                          pypyr.errors.ControlOfFlowInstruction
-        context: pypyr.context.Context. Look for config in this context
-                 instance.
-        context_key: str name of step config in context.
-
-    """
-    assert name, ("name parameter must exist for a ControlOfFlowStep.")
-    assert context, ("context param must exist for ControlOfFlowStep.")
-    # this way, logs output as the calling step, which makes more sense
-    # to end-user than a mystery steps.dsl.blah logging output.
-    logger = logging.getLogger(name)
-    logger.debug("starting")
-
-    context.assert_key_has_value(key=context_key, caller=name)
-    original_config = (context_key, context[context_key])
-
-    config = context.get_formatted(context_key)
-
+def instruction_from_dict(config: Mapping,
+                          name: str,
+                          instruction_type: type[ControlOfFlowInstruction],
+                          context_key: str,
+                          original_config: tuple[str, Mapping]):
+    """Create a Call or Jump from input dict."""
     if isinstance(config, str):
         groups = [config]
         success_group = None
@@ -76,15 +59,166 @@ def control_of_flow_instruction(name, instruction_type, context, context_key):
         raise ContextError(
             f"{context_key}.failure must be a string for {name}.")
 
+    return instruction_type(groups=groups,
+                            success_group=success_group,
+                            failure_group=failure_group,
+                            original_config=original_config)
+
+
+def control_of_flow_instruction(
+        name: str,
+        instruction_type: type[ControlOfFlowInstruction],
+        context: Context,
+        context_key: str):
+    """Run a control of flow instruction.
+
+    The step config in the context dict looks like this:
+        <<instruction-name>>: <<cmd string>>. Mandatory.
+
+        OR, as a dict
+        <<instruction-name:
+            groups: <<str>> or <<list of str>> - mandatory.
+            success: <<str>>
+            failure: <<str>>
+
+    Args:
+        name: Unique name for step. Likely __name__ of calling step.
+        instruction_type: Type - must inherit from
+                          pypyr.errors.ControlOfFlowInstruction
+        context: pypyr.context.Context. Look for config in this context
+                 instance.
+        context_key: str name of step config in context.
+
+    """
+    assert name, ("name parameter must exist for a ControlOfFlowStep.")
+    assert context, ("context param must exist for ControlOfFlowStep.")
+    # this way, logs output as the calling step, which makes more sense
+    # to end-user than a mystery steps.dsl.blah logging output.
+    logger = logging.getLogger(name)
+    logger.debug("starting")
+
+    context.assert_key_has_value(key=context_key, caller=name)
+    original_config = (context_key, context[context_key])
+
+    config = context.get_formatted(context_key)
+
+    cof_instruction = instruction_from_dict(config=config,
+                                            name=name,
+                                            instruction_type=instruction_type,
+                                            context_key=context_key,
+                                            original_config=original_config)
+
     logger.info(
         ("step %s about to hand over control with %s: Will run groups: %s "
          " with success %s and failure %s"),
         name,
         context_key,
-        groups,
-        success_group,
-        failure_group)
-    raise instruction_type(groups=groups,
-                           success_group=success_group,
-                           failure_group=failure_group,
-                           original_config=original_config)
+        cof_instruction.groups,
+        cof_instruction.success_group,
+        cof_instruction.failure_group)
+    raise cof_instruction
+
+
+def switch(context: Context, name: str) -> None:
+    """Run a call instruction from switch where case applies.
+
+    Context expects the following keys:
+        switch:
+            - case: expression. exec `call` when expression True.
+              call: str. Single group-name to run.
+
+            - default: exec `call` when none of the case expressions True.
+
+    OR
+
+        switch:
+            - case: expression. exec call `when` expression True.
+              call:
+                groups: list[str] | str. Single group or list of groups to run.
+                success: str. Name of group to run on success completion.
+                failure: str. Name of group to run on something going wrong.
+
+    `default` is optional. If you specify default, it must be the last item in
+    the switch list.
+
+    Args:
+        context: pypyr.context.Context: input context
+        name: name of calling step. Very like `pypyr.steps.switch`.
+    """
+    # this way, logs output as the calling step, which makes more sense
+    # to end-user than a mystery steps.dsl.blah logging output.
+    logger = logging.getLogger(name)
+    logger.debug("starting")
+
+    context.assert_key_has_value(key=SWITCH_KEY, caller=name)
+
+    switch_config = context[SWITCH_KEY]
+    # allows runtime to reset switch input when nested switches
+    original_config = (SWITCH_KEY, switch_config)
+
+    last_index = len(switch_config) - 1
+    cof_instruction = None
+    raw_call = None
+    is_default = False
+    case_expression = False
+
+    for i, case in enumerate(switch_config):
+        logger.debug("evaluating case %s", case)
+        if i == last_index:
+            # last one might be default
+            default_case = case.get('default')
+
+            # this is default on the last case in the list
+            is_default = default_case is not None
+
+        if is_default:
+            logger.debug("no switch case True. running default...")
+            raw_call = default_case
+        else:
+            # `case` could be None or ''.
+            raw_expression = case.get('case', sentinel)
+
+            if raw_expression is sentinel:
+                raise KeyNotInContextError(
+                    f"'case' not found in `switch` index {i}.")
+
+            try:
+                # `call` must exist
+                raw_call = case['call']
+            except KeyError as err:
+                raise KeyNotInContextError(
+                    f"'call' not found in `switch` index {i}.") from err
+
+            # `call` must have a value
+            if not raw_call:
+                raise KeyInContextHasNoValueError(
+                    f"'call' does not have a value at `switch` index {i}.")
+
+            case_expression = context.get_formatted_as_type(raw_expression,
+                                                            out_type=bool)
+            if case_expression:
+                logger.debug("case %s is True. running `call` group...",
+                             raw_expression)
+
+        if case_expression or is_default:
+            # only doing expensive format if case True.
+            cof_instruction = instruction_from_dict(
+                context.get_formatted_value(raw_call),
+                name=name,
+                instruction_type=Call,
+                context_key=SWITCH_KEY,
+                original_config=original_config)
+            break
+
+    if cof_instruction:
+        logger.info(
+            ("step %s about to hand over control: Will call groups: %s "
+             " with success %s and failure %s"),
+            name,
+            cof_instruction.groups,
+            cof_instruction.success_group,
+            cof_instruction.failure_group)
+        raise cof_instruction
+    else:
+        logger.info("no matching case found in switch.")
+        logger.debug("done")

--- a/pypyr/steps/switch.py
+++ b/pypyr/steps/switch.py
@@ -1,0 +1,48 @@
+"""Control of flow instruction to switch between groups (if-else)."""
+import logging
+from pypyr.steps.dsl.cof import switch
+
+logger = logging.getLogger(__name__)
+
+
+def run_step(context):
+    """Control of flow instruction to switch between step-groups.
+
+    Call hands control back to this step upon completion, so execution
+    continues from this point on-ward when the called groups are done.
+
+    No fallthrough - will run the first matching group and not evaluate any
+    case expressions thereafter.
+
+    Args:
+        context: pypyr.context.Context
+
+    Context expects the following keys:
+        switch:
+            - case: expression. exec `call` when expression True.
+              call: str. Single group-name to run.
+
+            - default: exec `call` when none of the case expressions True.
+
+    OR
+
+        switch:
+            - case: expression. exec call `when` expression True.
+              call:
+                groups: list[str] | str. Single group or list of groups to run.
+                success: str. Name of group to run on success completion.
+                failure: str. Name of group to run on something going wrong.
+
+    `default` is optional. If you specify default, it must be the last item in
+    the switch list.
+
+    Return:
+        None.
+    """
+    logger.debug("started")
+
+    switch(context=context, name=__name__)
+
+    # this will only run if no case condition true - else switch will kick out
+    # of method with a raise.
+    logger.debug("done")

--- a/tests/integration/pypyr/switch/switch_int_test.py
+++ b/tests/integration/pypyr/switch/switch_int_test.py
@@ -1,0 +1,17 @@
+"""Nested calls inside loops. These pipelines are in ./tests/pipelines/."""
+from pypyr import pipelinerunner
+
+
+def test_switch_nested():
+    """Nested switch control-of-flow works."""
+    out = pipelinerunner.run('tests/pipelines/switch/nested')
+
+    assert out == {'out': [
+        'begin',
+        'A.1',
+        'B',
+        'A.2',
+        'C',
+        'A.3',
+        'end.'
+    ]}

--- a/tests/pipelines/switch/nested.yaml
+++ b/tests/pipelines/switch/nested.yaml
@@ -1,0 +1,74 @@
+steps:
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: begin
+
+  - name: pypyr.steps.switch
+    in:
+      switch:
+        - case: True
+          call: A
+        - case: False
+          call: never
+
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: end.
+
+A:
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: A.1
+
+  - name: pypyr.steps.switch
+    in:
+      switch:
+        - case: True
+          call: B
+
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: A.2
+
+  - name: pypyr.steps.switch
+    in:
+      switch:
+        - case: False
+          call: B
+        - case: True
+          call: C
+
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: A.3
+
+B:
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: B
+
+C:
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: C
+
+never:
+  - name: pypyr.steps.append
+    in:
+      append:
+        list: out
+        addMe: never

--- a/tests/unit/pypyr/steps/dsl/cof_test.py
+++ b/tests/unit/pypyr/steps/dsl/cof_test.py
@@ -1,15 +1,19 @@
 """cof.py unit tests."""
 import logging
+
 import pytest
+
 from pypyr.context import Context
 from pypyr.errors import (Call,
                           ContextError,
                           Jump,
                           KeyInContextHasNoValueError,
                           KeyNotInContextError)
-from pypyr.steps.dsl.cof import control_of_flow_instruction as cof_func
+from pypyr.steps.dsl.cof import control_of_flow_instruction as cof_func, switch
 
 from tests.common.utils import patch_logger
+
+# region control_of_flow_instruction
 
 # cof_func(name, instruction_type, context, context_key)
 
@@ -257,3 +261,306 @@ def test_cof_dict_with_all_args_formatting_to_string():
                                            'success': '{sg}',
                                            'failure': '{fg}'
                                            })
+
+# endregion control_of_flow_instruction
+
+# region switch
+
+
+def test_switch_no_switch_input():
+    """Raise error when no switch input key on switch."""
+    with pytest.raises(KeyNotInContextError) as err:
+        switch(Context({'a': 'b'}), 'blah')
+
+    assert str(err.value) == ("context['switch'] doesn't exist. It must exist "
+                              "for blah.")
+
+
+def test_switch_context_key_exists_but_none():
+    """Raise error when switch key exists but is None."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        switch(Context({'switch': None}), 'blah')
+
+    assert str(err.value) == (
+        "context['switch'] must have a value for blah.")
+
+
+def test_switch_missing_case():
+    """Switch raises if list element found with no case key."""
+    with pytest.raises(KeyNotInContextError) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'case1': True,
+            'fg': 'fgv',
+            'switch': [
+                {'caseX': '{case1}', 'call': '{list}'},
+                {'case': '{case1}', 'call': 'sg2'},
+            ]}),
+            name='blah')
+
+    assert str(err.value) == "'case' not found in `switch` index 0."
+
+
+def test_switch_missing_case_because_out_of_order_default():
+    """Switch raises if default not last."""
+    with pytest.raises(KeyNotInContextError) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'case1': False,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'default': 'blah'},
+                {'case': '{case1}', 'call': 'sg2'},
+            ]}),
+            name='blah')
+
+    assert str(err.value) == "'case' not found in `switch` index 1."
+
+
+def test_switch_empty_case():
+    """Switch allows empty or None case."""
+    switch(context=Context({
+        'list': 'sg1',
+        'case1': True,
+        'fg': 'fgv',
+        'switch': [
+                {'case': '', 'call': '{list}'},
+                {'case': None, 'call': 'sg2'},
+        ]}),
+        name='blah')
+
+
+def test_switch_missing_call():
+    """Switch raises if list element found with no call key."""
+    with pytest.raises(KeyNotInContextError) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'case1': False,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case1}', 'callX': 'sg2'},
+            ]}),
+            name='blah')
+
+    assert str(err.value) == "'call' not found in `switch` index 1."
+
+
+def test_switch_call_no_value():
+    """Switch raises if list element found with call key with no value."""
+    with pytest.raises(KeyInContextHasNoValueError) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'case1': False,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case1}', 'call': ''},
+            ]}),
+            name='blah')
+
+    assert str(err.value) == (
+        "'call' does not have a value at `switch` index 1.")
+
+
+def test_switch_first():
+    """Switch only runs first if case True."""
+    with pytest.raises(Call) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'case1': True,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case1}', 'call': 'sg2'},
+            ]}),
+            name='blah')
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg1']
+    assert cof.success_group is None
+    assert cof.failure_group is None
+    assert cof.original_config == ('switch', [
+        {'case': '{case1}', 'call': '{list}'},
+        {'case': '{case1}', 'call': 'sg2'},
+    ])
+
+
+def test_switch_last():
+    """Switch only runs last if case True."""
+    with pytest.raises(Call) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'case1': False,
+            'case2': True,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case2}', 'call': 'sg2'},
+            ]}),
+            name='blah')
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg2']
+    assert cof.success_group is None
+    assert cof.failure_group is None
+    assert cof.original_config == ('switch', [
+        {'case': '{case1}', 'call': '{list}'},
+        {'case': '{case2}', 'call': 'sg2'},
+    ])
+
+
+def test_switch_default():
+    """Switch only runs default if no case True."""
+    with pytest.raises(Call) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'def': 'sg3',
+            'case1': False,
+            'case2': False,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case2}', 'call': 'sg2'},
+                {'default': '{def}'}
+            ]}),
+            name='blah')
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg3']
+    assert cof.success_group is None
+    assert cof.failure_group is None
+    assert cof.original_config == ('switch', [
+        {'case': '{case1}', 'call': '{list}'},
+        {'case': '{case2}', 'call': 'sg2'},
+        {'default': '{def}'}
+    ])
+
+
+def test_switch_default_list_input():
+    """Switch only runs default if no case True with >1 groups."""
+    with pytest.raises(Call) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'def': 'sg3',
+            'case1': False,
+            'case2': False,
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case2}', 'call': 'sg2'},
+                {'default': ['{def}', 'sg4']}
+            ]}),
+            name='blah')
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg3', 'sg4']
+    assert cof.success_group is None
+    assert cof.failure_group is None
+    assert cof.original_config == ('switch', [
+        {'case': '{case1}', 'call': '{list}'},
+        {'case': '{case2}', 'call': 'sg2'},
+        {'default': ['{def}', 'sg4']}
+    ])
+
+
+def test_switch_default_all_call_inputs():
+    """Switch only runs default if no case True with all call inputs."""
+    with pytest.raises(Call) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'def': 'sg3',
+            'case1': False,
+            'case2': False,
+            'sg': 'sgv',
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case2}', 'call': 'sg2'},
+                {'default': {
+                    'groups': ['{def}', 'sg4'],
+                    'success': '{sg}',
+                    'failure': '{fg}'
+                }}
+            ]}),
+            name='blah')
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg3', 'sg4']
+    assert cof.success_group == 'sgv'
+    assert cof.failure_group == 'fgv'
+    assert cof.original_config == ('switch', [
+        {'case': '{case1}', 'call': '{list}'},
+        {'case': '{case2}', 'call': 'sg2'},
+        {'default': {
+            'groups': ['{def}', 'sg4'],
+            'success': '{sg}',
+            'failure': '{fg}'
+        }}
+    ])
+
+
+def test_switch_case_all_call_inputs():
+    """Switch runs case in the middle with all call inputs."""
+    with pytest.raises(Call) as err:
+        switch(context=Context({
+            'list': 'sg1',
+            'def': 'sg3',
+            'sg2_input': 'sg2',
+            'case1': False,
+            'case2': True,
+            'sg': 'sgv',
+            'fg': 'fgv',
+            'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case2}', 'call': {
+                    'groups': '{sg2_input}',
+                    'success': '{sg}',
+                    'failure': '{fg}'}},
+                {'default': {
+                    'groups': ['{def}', 'sg4'],
+                    'success': '{sg}d',
+                    'failure': '{fg}d'
+                }}
+            ]}),
+            name='blah')
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg2']
+    assert cof.success_group == 'sgv'
+    assert cof.failure_group == 'fgv'
+    assert cof.original_config == ('switch', [
+        {'case': '{case1}', 'call': '{list}'},
+        {'case': '{case2}', 'call': {
+            'groups': '{sg2_input}',
+            'success': '{sg}',
+            'failure': '{fg}'}},
+        {'default': {
+            'groups': ['{def}', 'sg4'],
+            'success': '{sg}d',
+            'failure': '{fg}d'
+        }}
+    ])
+
+
+def test_switch_none_no_default():
+    """Switch does nothing if no cases True and no default set."""
+    switch(context=Context({
+        'list': 'sg1',
+        'case1': False,
+        'case2': False,
+        'fg': 'fgv',
+        'switch': [
+                {'case': '{case1}', 'call': '{list}'},
+                {'case': '{case2}', 'call': 'sg2'},
+        ]}),
+        name='blah')
+
+# endregion switch

--- a/tests/unit/pypyr/steps/switch_test.py
+++ b/tests/unit/pypyr/steps/switch_test.py
@@ -1,0 +1,37 @@
+"""switch.py unit tests. Most of the tests are in pypyr.steps.dsl.cof."""
+import pytest
+
+from pypyr.context import Context
+from pypyr.errors import Call
+from pypyr.steps.switch import run_step
+
+
+def test_switch_step_calls_cof():
+    """Switch step calls through to dsl."""
+    with pytest.raises(Call) as err:
+        run_step(Context({
+            'switch': [
+                {'case': False, 'call': 'sg1'},
+                {'case': True, 'call': 'sg2'}
+            ]
+        }))
+
+    cof = err.value
+    assert isinstance(cof, Call)
+    assert cof.groups == ['sg2']
+    assert cof.success_group is None
+    assert cof.failure_group is None
+    assert cof.original_config == ('switch', [
+        {'case': False, 'call': 'sg1'},
+        {'case': True, 'call': 'sg2'},
+    ])
+
+
+def test_switch_step_nothing():
+    """No success match on switch case just carries on."""
+    run_step(Context({
+        'switch': [
+            {'case': False, 'call': 'sg1'},
+            {'case': False, 'call': 'sg2'}
+        ]
+    }))


### PR DESCRIPTION
The switch step allows switch-case (aka if-elif-else) style branching to different step-groups based upon case expressions.

- Add pypyr.steps.switch
- Refactor steps.dsl.cof to support switch.
- Unit + Integration tests for switch.
- closes #298