### PR TITLE
argskwargs parser & partitioning on = for kvp

### DIFF
--- a/pypyr/__init__.py
+++ b/pypyr/__init__.py
@@ -5,6 +5,6 @@ NOTIFY (25) log level and notify() method to the global logger object.
 """
 import pypyr.log.logger
 
-__version__ = "5.6.0"
+__version__ = "5.7.0"
 
 pypyr.log.logger.set_up_notify_log_level()

--- a/pypyr/parser/argskwargs.py
+++ b/pypyr/parser/argskwargs.py
@@ -1,0 +1,65 @@
+"""Context parser that returns a list from input arguments.
+
+Takes input args (i.e separated by spaces on cli) and returns a list named
+argList.
+
+Where args are key=value pairs, returns a dictionary where each pair becomes a
+dictionary element.
+
+Don't have spaces in your values unless your really mean it. "k1=v1 ' k2'=v2"
+will result in a context key name of ' k2' not 'k2'.
+
+So cli input like this "ham eggs bacon drink=coffee", will yield context:
+{ 'argList': ['ham', 'eggs', 'bacon'], 'drink': 'coffee'}
+"""
+# can remove __future__ once py 3.10 the lowest supported version
+from __future__ import annotations
+from collections.abc import Mapping
+import logging
+
+logger = logging.getLogger(__name__)
+
+ARG_LIST_KEY = 'argList'
+
+
+def get_parsed_context(args: list[str] | None) -> Mapping:
+    """Create dict from combination of args & kwargs passed from cli.
+
+    This supports the style of args that makefile does, i.e
+
+    $ pypyr pipeline-name arg1 arg2 key1=value1 key2-"value 2"
+
+    args go to context key `argList`. key=value pairs become context dictionary
+    elements at root.
+
+    Args:
+      args: list of string. Passed from command-line invocation where:
+            $ pypyr pipelinename this is the context_arg
+            This would result in args == ['this', 'is', 'the', 'context_arg']
+
+    Returns:
+      dict. This dict will initialize the context for the pipeline run.
+            The dict will have key `argList` with empty list [] if no args
+            passed.
+    """
+    logger.debug("starting")
+    if not args:
+        logger.debug(
+            "pipeline invoked without context arg set. For this\n"
+            "argskwargs parser you're looking for something like:\n"
+            "pypyr pipelinename arg1 arg2 k1=v1 k2=\"v 2\""
+        )
+        return {ARG_LIST_KEY: []}
+    arg_list = []
+    out: dict[str, str | list] = {}
+    for a in args:
+        # 1st = is separator, subsequent = just taken as part of the value
+        key, sep, value = a.partition('=')
+        if sep:
+            out[key] = value
+        else:
+            arg_list.append(a)
+
+    out[ARG_LIST_KEY] = arg_list
+
+    return out

--- a/pypyr/parser/dict.py
+++ b/pypyr/parser/dict.py
@@ -29,4 +29,5 @@ def get_parsed_context(args):
 
     # for each input argument, project key=value
     return {'argDict':
-            dict(element.split('=') for element in args)}
+            {k: v for k, _, v in (element.partition('=') for element in args)}
+            }

--- a/pypyr/parser/keyvaluepairs.py
+++ b/pypyr/parser/keyvaluepairs.py
@@ -26,4 +26,4 @@ def get_parsed_context(args):
         return None
 
     # for each arg, project key=value
-    return dict(element.split('=') for element in args)
+    return {k: v for k, _, v in (element.partition('=') for element in args)}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.6.0
+current_version = 5.7.0
 
 [bumpversion:file:pypyr/__init__.py]
 

--- a/tests/unit/pypyr/parser/argskwargs_test.py
+++ b/tests/unit/pypyr/parser/argskwargs_test.py
@@ -1,0 +1,34 @@
+"""Unit tests for pypyr.parser.argskwargs."""
+
+from pypyr.parser.argskwargs import get_parsed_context
+
+
+def test_argskwargs_empty_input():
+    """Parse empty inputs."""
+    assert get_parsed_context([]) == {'argList': []}
+    assert get_parsed_context(None) == {'argList': []}
+
+
+def test_argskwargs_args_only():
+    """Parse when only args."""
+    assert get_parsed_context(['a']) == {'argList': ['a']}
+    assert get_parsed_context(['a', 'b b', 'c']) == {'argList':
+                                                     ['a', 'b b', 'c']}
+
+
+def test_argskwargs_kwargs_only():
+    """Parse when only kwargs."""
+    assert get_parsed_context(['k1=value 1']) == {'argList': [],
+                                                  'k1': 'value 1'}
+    assert get_parsed_context(['k1=value 1', 'k2=v2=3']) == {'argList': [],
+                                                             'k1': 'value 1',
+                                                             'k2': 'v2=3'}
+
+
+def test_argskwargs_args_and_kwargs():
+    """Parse when args + kwargs."""
+    assert get_parsed_context(['a', 'b', 'c d',
+                               'k1="value 1"', 'k2=v2']) == {
+        'argList': ['a', 'b', 'c d'],
+        'k1': '"value 1"',
+        'k2': 'v2'}

--- a/tests/unit/pypyr/parser/dict_test.py
+++ b/tests/unit/pypyr/parser/dict_test.py
@@ -1,6 +1,5 @@
 """dict.py unit tests."""
 import pypyr.parser.dict
-import pytest
 
 
 def test_arg_string_parses_to_argdict():
@@ -28,10 +27,25 @@ def test_arg_string_parses_to_single_entry_argdict():
 
 
 def test_no_equals_string_parses_to_single_entry_argdict():
-    """No equals input kvp string fails with ValueError."""
-    with pytest.raises(ValueError):
-        pypyr.parser.dict.get_parsed_context(
-            'key1value2,value3')
+    """No equals input kvp parses to key=''."""
+    out = pypyr.parser.dict.get_parsed_context(['key1value2,value3'])
+    assert out == {'argDict': {'key1value2,value3': ''}}
+
+
+def test_argdict_no_equals_combined_with_equals():
+    """No equals input kvp string parses to key='' and key=value."""
+    out = pypyr.parser.dict.get_parsed_context(
+        ['key1value2,value3', 'key 1=value 1'])
+    assert out == {'argDict': {'key1value2,value3': '',
+                               'key 1': 'value 1'}}
+
+
+def test_argdict_no_equals_combined_with_double_equals():
+    """Ignore subsequent equals."""
+    out = pypyr.parser.dict.get_parsed_context(
+        ['key1value2,value3', 'key 1=value 1=123'])
+    assert out == {'argDict': {'key1value2,value3': '',
+                               'key 1': 'value 1=123'}}
 
 
 def test_empty_string_empty_dict_argdict():

--- a/tests/unit/pypyr/parser/keyvaluepairs_test.py
+++ b/tests/unit/pypyr/parser/keyvaluepairs_test.py
@@ -1,6 +1,5 @@
 """keyvaluepairs.py unit tests."""
 import pypyr.parser.keyvaluepairs
-import pytest
 
 
 def test_kvp_args_parses_to_dict():
@@ -21,11 +20,28 @@ def test_kvp_args_single_parses_to_single_entry():
     assert len(out) == 1, "1 item expected"
 
 
-def test_no_equals_arg_parses_to_single_entry_fail():
-    """No equals input kvp args fails with ValueError."""
-    with pytest.raises(ValueError):
-        pypyr.parser.keyvaluepairs.get_parsed_context(
-            ['key1value2,value3'])
+def test_kvp_args_single_no_equals():
+    """No equals input kvp ends up as key: ''."""
+    out = pypyr.parser.keyvaluepairs.get_parsed_context(
+        ['key1value2,value3'])
+
+    assert out == {'key1value2,value3': ''}
+
+
+def test_kvp_args_no_equals_and_equals():
+    """No equals input combined with equals key value pair."""
+    out = pypyr.parser.keyvaluepairs.get_parsed_context(
+        ['key1value2,value3', "key1=123"])
+
+    assert out == {'key1value2,value3': '', 'key1': '123'}
+
+
+def test_kvp_args_ignore_double_equals():
+    """Ignore double equals."""
+    out = pypyr.parser.keyvaluepairs.get_parsed_context(
+        ['key1value2,value3', "key 1=123=45 6"])
+
+    assert out == {'key1value2,value3': '', 'key 1': '123=45 6'}
 
 
 def test_kvp_empty_args_empty_dict():


### PR DESCRIPTION
- new `argskwargs` parser for combining list of args with keyword args. closes #284.
- amend `keyvaluepairs` and `dict` parsers to allow unescaped = in values - only the 1st `=` is now taken to identify the key, the subsequent string becomes the value.
  - similarly, inputs without `=` will not raise a ValueError anymore, instead it will parse to `key: ''` - i.e the arg input value as key with an empty string as a value.
- minor release bump