### PR TITLE
pypyr.steps.filereplace get_formatted X2

### DIFF
--- a/pypyr/steps/dsl/fileinoutrewriter.py
+++ b/pypyr/steps/dsl/fileinoutrewriter.py
@@ -170,11 +170,8 @@ class StreamReplacePairsRewriterStep(FileInRewriterStep):
 
     def run_step(self):
         """Write in to out, replacing strings per the replace_pairs."""
-        formatted_replacements = self.context.get_formatted_value(
-            self.replace_pairs)
-
         iter = StreamReplacePairsRewriterStep.iter_replace_strings(
-            formatted_replacements)
+            self.replace_pairs)
         rewriter = StreamRewriter(iter,
                                   encoding_in=self.encoding_in,
                                   encoding_out=self.encoding_out)


### PR DESCRIPTION
- `get_formatted` runs a redundant second time on filereplace inputs. Mostly this will just result in burning unnecessary CPU, but it will also cause `ff` flat format directives to get lost.
- closes #303.