### PR TITLE
py 3.11 & conditional tomli dep

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
         include:
           - os: windows-latest
-            python-version: '3.10'
+            python-version: 3.11
             
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,13 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Typing :: Typed",
 ]
 dependencies = [
   "python-dateutil",
   "ruamel.yaml",
-  "tomli",
+  "tomli >= 1.1.0 ; python_version < '3.11'",
   "tomli-w",
 ]
 description = "task-runner for automation pipelines defined in yaml. cli & api."

--- a/pypyr/toml.py
+++ b/pypyr/toml.py
@@ -1,5 +1,11 @@
 """Toml handling."""
-import tomli as toml_reader
+try:
+    # can get rid of the try soon as py 3.11 min supported version
+    # reason is py 3.11 includes tomli in stdlib
+    import tomllib as toml_reader
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as toml_reader
+
 import tomli_w as toml_writer  # type: ignore
 
 

--- a/tests/unit/pypyr/steps/fetchtoml_test.py
+++ b/tests/unit/pypyr/steps/fetchtoml_test.py
@@ -2,7 +2,13 @@
 from unittest.mock import mock_open, patch
 
 import pytest
-from tomli import TOMLDecodeError
+
+try:
+    # can get rid of the try soon as py 3.11 min supported version
+    # reason is py 3.11 includes tomli in stdlib
+    from tomllib import TOMLDecodeError
+except ModuleNotFoundError:
+    from tomli import TOMLDecodeError
 
 from pypyr.context import Context
 from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError


### PR DESCRIPTION
- Add python 3.11 trove classifiers.
- Only install tomli when python_version < 3.11.
- Conditional import of tomli.
- Github action add 3.11 runner.