### PR TITLE
clear all cache, codecov token, tox 4 

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -39,3 +39,5 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,3 +26,5 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pypyr/cache/admin.py
+++ b/pypyr/cache/admin.py
@@ -1,0 +1,25 @@
+"""Administrate pypyr caches."""
+import logging
+
+from pypyr.cache.backoffcache import backoff_cache
+from pypyr.cache.filecache import file_cache
+from pypyr.cache.loadercache import loader_cache
+from pypyr.cache.namespacecache import pystring_namespace_cache
+from pypyr.cache.parsercache import contextparser_cache
+from pypyr.cache.stepcache import step_cache
+
+logger = logging.getLogger(__name__)
+
+
+def clear_all() -> None:
+    """Clear all pypyr caches."""
+    logger.debug("clearing all cache...")
+
+    backoff_cache.clear()
+    file_cache.clear()
+    loader_cache.clear()
+    pystring_namespace_cache.clear()
+    contextparser_cache.clear()
+    step_cache.clear()
+
+    logger.debug("all cache cleared.")

--- a/pypyr/cache/filecache.py
+++ b/pypyr/cache/filecache.py
@@ -1,0 +1,12 @@
+"""Global cache for pipelines found by pypyr.loaders.file.
+
+Map file path to file contents.
+
+Attributes:
+    file_cache: Global instance of the file loader cache.
+                Use this attribute to access the cache from elsewhere.
+"""
+
+from pypyr.cache.cache import Cache
+
+file_cache = Cache()

--- a/pypyr/loaders/file.py
+++ b/pypyr/loaders/file.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 
-from pypyr.cache.cache import Cache
+from pypyr.cache.filecache import file_cache
 from pypyr.config import config
 from pypyr.errors import PipelineNotFoundError
 from pypyr.moduleloader import add_sys_path
@@ -11,8 +11,6 @@ import pypyr.yaml
 
 logger = logging.getLogger(__name__)
 
-
-_file_cache = Cache()
 cwd_pipelines_dir = config.cwd.joinpath(config.pipelines_subdir)
 pypyr_dir = Path(__file__).parents[1]
 builtin_pipelines_dir = pypyr_dir.joinpath('pipelines')
@@ -151,7 +149,7 @@ def get_pipeline_definition(pipeline_name, parent):
 
     logger.debug("Trying to open pipeline at path %s", pipeline_path)
 
-    pipeline_definition = _file_cache.get(
+    pipeline_definition = file_cache.get(
         str(pipeline_path),
         lambda: load_pipeline_from_file(pipeline_path))
 

--- a/tests/unit/pypyr/cache/admin_test.py
+++ b/tests/unit/pypyr/cache/admin_test.py
@@ -1,0 +1,53 @@
+"""pypyr/cache/admin.py unit tests."""
+import pypyr.cache.admin as cache_admin
+
+from pypyr.cache.backoffcache import backoff_cache
+from pypyr.cache.filecache import file_cache
+from pypyr.cache.loadercache import loader_cache
+from pypyr.cache.namespacecache import pystring_namespace_cache
+from pypyr.cache.parsercache import contextparser_cache
+from pypyr.cache.stepcache import step_cache
+from pypyr.retries import builtin_backoffs
+
+# region load_backoff_callable
+
+
+def test_cache_clear_all():
+    """Clear all cache."""
+    cache_admin.clear_all()
+
+    assert backoff_cache._cache == builtin_backoffs
+    assert file_cache._cache == {}
+    assert loader_cache._cache == {}
+    assert pystring_namespace_cache._cache == {}
+    assert contextparser_cache._cache == {}
+    assert step_cache._cache == {}
+
+    backoff_cache.get_backoff('tests.arbpack.arbcallables.ArbCallable')
+    assert len(backoff_cache._cache) == len(builtin_backoffs) + 1
+
+    # testing full file cache clear in pypyr/loaders/file_test.py in:
+    # test_get_pipeline_definition_clear_all_cache
+    file_cache._cache['arb'] = 'delete me'
+    assert len(file_cache._cache) == 1
+
+    loader_cache.get_pype_loader('tests.arbpack.arbloader')
+    assert len(loader_cache._cache) == 1
+
+    pystring_namespace_cache.get_namespace('import math')
+    assert len(pystring_namespace_cache._cache) == 1
+
+    contextparser_cache.get_context_parser('tests.arbpack.arbparser')
+    assert len(contextparser_cache._cache) == 1
+
+    step_cache.get_step('tests.arbpack.arbmutatingstep')
+    assert len(step_cache._cache) == 1
+
+    cache_admin.clear_all()
+
+    assert backoff_cache._cache == builtin_backoffs
+    assert file_cache._cache == {}
+    assert loader_cache._cache == {}
+    assert pystring_namespace_cache._cache == {}
+    assert contextparser_cache._cache == {}
+    assert step_cache._cache == {}

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ skipsdist = false
 [testenv]
 commands = pypyr {posargs}
 extras = dev
-passenv = CI HOME GITHUB_* TWINE_* FLIT_*
+passenv = CI, HOME, GITHUB_*, TWINE_*, FLIT_*
 usedevelop = true


### PR DESCRIPTION
- upgrade to tox 4.
  - breaking change on passenv going comma rather than space delimited.
- codecov add token to GitHub action to avoid sporadic errors on codecov coverage upload
- Add clear all function to wipe all pypyr caches. Closes #316