### PR TITLE
no cache mode

### DIFF
--- a/pypyr/cache/cache.py
+++ b/pypyr/cache/cache.py
@@ -2,6 +2,8 @@
 import logging
 import threading
 
+from pypyr.config import config
+
 # use pypyr logger to ensure loglevel is set correctly
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,9 @@ class Cache():
         Be warned that get happens under the context of a Lock. . . so if
         creator takes a long time you might well be blocking.
 
+        If config no_cache is True, bypasses cache entirely - will call
+        creator each time and also not save the result to cache.
+
         Args:
             key: key (unique id) of cached item
             creator: callable that will create cached object if key not found
@@ -41,12 +46,17 @@ class Cache():
         Returns:
             Cached item at key or the result of creator()
         """
+        if config.no_cache:
+            logger.debug("no cache mode enabled. creating `%s` sans cache",
+                         key)
+            return creator()
+
         with self._lock:
             if key in self._cache:
-                logger.debug("%s loading from cache", key)
+                logger.debug("`%s` loading from cache", key)
                 obj = self._cache[key]
             else:
-                logger.debug("%s not found in cache. . . creating", key)
+                logger.debug("`%s` not found in cache. . . creating", key)
                 obj = creator()
                 self._cache[key] = obj
 

--- a/pypyr/config.py
+++ b/pypyr/config.py
@@ -64,6 +64,7 @@ class Config():
             Set by init().
         vars: dict. User provided variables to write into the pypyr context.
             Set by init().
+        no_cache: bool. Default False. Bypass all pypyr caches entirely.
         platform_paths: pypyr.platform.PlatformPaths: O/S specific paths to
             config files & data dirs. Set by init().
         pyproject_toml: dict. The pyproject.toml file as a dict in a full.
@@ -90,6 +91,8 @@ class Config():
         'default_group',
         'default_success_group',
         'default_failure_group',
+        # flags
+        'no_cache',
         # functional
         'shortcuts',
         'vars'}
@@ -124,6 +127,10 @@ class Config():
         self.default_group = 'steps'
         self.default_success_group = 'on_success'
         self.default_failure_group = 'on_failure'
+
+        # flags
+        self.no_cache: bool = cast_str_to_bool(os.getenv('PYPYR_NO_CACHE',
+                                                         '0'))
 
         # functional
         self.shortcuts: dict = {}

--- a/tests/unit/pypyr/cache/backoffcache_test.py
+++ b/tests/unit/pypyr/cache/backoffcache_test.py
@@ -73,6 +73,30 @@ def test_get_backoff_builtin():
     assert callable_ref(789) == 123
     assert callable_ref(999) == 123
 
+
+@pytest.fixture
+def no_cache(monkeypatch):
+    """Set no cache."""
+    monkeypatch.setattr('pypyr.cache.cache.config.no_cache', True)
+
+
+def test_get_backoff_builtin_no_cache(no_cache):
+    """Load built-in backoff callable when no_cache true."""
+    backoff_cache = backoffcache.BackoffCache()
+    f = backoff_cache.get_backoff('fixed')
+
+    callable_ref = f(sleep=123, max_sleep=456)
+    assert callable_ref(789) == 123
+    assert callable_ref(999) == 123
+
+    f2 = backoff_cache.get_backoff('fixed')
+    callable_ref = f2(sleep=789, max_sleep=1000)
+    assert callable_ref(111) == 789
+
+    # didn't add anything to cache even when calling same built-in twice,
+    # bypassing it entirely
+    assert backoff_cache._cache == pypyr.retries.builtin_backoffs
+
 # endregion BackoffCache: get_backoff
 
 # region BackoffCache: clear

--- a/tests/unit/pypyr/config_test.py
+++ b/tests/unit/pypyr/config_test.py
@@ -24,6 +24,7 @@ def no_envs(monkeypatch):
     monkeypatch.delenv('PYPYR_SKIP_INIT', raising=False)
     monkeypatch.delenv('PYPYR_CONFIG_GLOBAL', raising=False)
     monkeypatch.delenv('PYPYR_CONFIG_LOCAL', raising=False)
+    monkeypatch.delenv('PYPYR_NO_CACHE', raising=False)
 
 # region default initialization
 
@@ -40,6 +41,8 @@ def test_config_defaults(no_envs):
     assert config.platform_paths is None
     assert config.pyproject_toml is None
     assert config.skip_init is False
+
+    assert config.no_cache is False
 
     assert config.vars == {}
     assert config.shortcuts == {}
@@ -67,8 +70,31 @@ def test_config_with_encoding(monkeypatch, no_envs):
     monkeypatch.setenv('PYPYR_ENCODING', 'arb')
     monkeypatch.setenv('PYPYR_CMD_ENCODING', 'arb2')
     config = Config()
-    config.default_encoding == 'arb'
-    config.default_cmd_encoding == 'arb2'
+    assert config.default_encoding == 'arb'
+    assert config.default_cmd_encoding == 'arb2'
+
+
+def test_config_with_no_cache(monkeypatch, no_envs):
+    """Set no cache via env variable."""
+    monkeypatch.setenv('PYPYR_NO_CACHE', '1')
+    config = Config()
+    assert config.no_cache is True
+
+    monkeypatch.setenv('PYPYR_NO_CACHE', 'TRUE')
+    config = Config()
+    assert config.no_cache is True
+
+    monkeypatch.setenv('PYPYR_NO_CACHE', 'true')
+    config = Config()
+    assert config.no_cache is True
+
+    monkeypatch.setenv('PYPYR_NO_CACHE', '0')
+    config = Config()
+    assert config.no_cache is False
+
+    monkeypatch.setenv('PYPYR_NO_CACHE', 'fAlse')
+    config = Config()
+    assert config.no_cache is False
 
 
 def test_config_platforms(monkeypatch):
@@ -737,6 +763,7 @@ log_config:
 log_date_format: '%Y-%m-%d %H:%M:%S'
 log_detail_format: '%(asctime)s %(levelname)s:%(name)s:%(funcName)s: %(message)s'
 log_notify_format: '%(message)s'
+no_cache: false
 pipelines_subdir: pipelines
 shortcuts: {{}}
 vars: {{}}
@@ -765,6 +792,7 @@ def test_config_all_str(mock_get_platform, no_envs):
                    b'[tool.pypyr]\n'
                    b'pipelines_subdir = "arb4"\n'
                    b'default_success_group = "dsg"\n'
+                   b'no_cache = true\n'
                    b'[tool.pypyr.vars]\n'
                    b'a = "e"\n'
                    b'f4 = 4'))
@@ -802,6 +830,8 @@ def test_config_all_str(mock_get_platform, no_envs):
 
     assert config.platform_paths == fake_pp
 
+    assert config.no_cache is True
+
     mock_get_platform.assert_called_once_with('pypyr', 'config.yaml')
 
     assert mock_files.mock_calls == [
@@ -825,6 +855,7 @@ log_config:
 log_date_format: '%Y-%m-%d %H:%M:%S'
 log_detail_format: '%(asctime)s %(levelname)s:%(name)s:%(funcName)s: %(message)s'
 log_notify_format: '%(message)s'
+no_cache: true
 pipelines_subdir: arb5
 shortcuts:
   s1: one
@@ -858,6 +889,7 @@ pyproject_toml:
     pypyr:
       pipelines_subdir: arb4
       default_success_group: dsg
+      no_cache: true
       vars:
         a: e
         f4: 4


### PR DESCRIPTION
Add no_cache config flag, defaulting to False.

When no_cache=True, pypyr will bypass the internal caches entirely. pypyr will NOT retrieve anything from cache nor save anything to cache while no_cache=True.

Setting this flag has no effect on items currently in cache, but any get() operation on a cache won't even look at these existing items while the no_cache flag is True, nor add anything new to the cache.

Add some special handling for built-in retry back-offs. These use the backoff cache to map the built-ins' simple short names (e.g `fixed`) to the fully qualified (`pypyr.retries.fixed`). In the case where the `no_cache` bypass hits `load_backoff_callable` directly, pull short-names directly from the `builtin_backoffs`. This effectively ignores the underlying cache, and the super's getter won't add the retrieved callable to cache either.

Closes #317.