### PR TITLE
Bump version: 5.7.1 → 5.8.0

### DIFF
--- a/pypyr/__init__.py
+++ b/pypyr/__init__.py
@@ -5,6 +5,6 @@ NOTIFY (25) log level and notify() method to the global logger object.
 """
 import pypyr.log.logger
 
-__version__ = "5.7.1"
+__version__ = "5.8.0"
 
 pypyr.log.logger.set_up_notify_log_level()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.7.1
+current_version = 5.8.0
 
 [bumpversion:file:pypyr/__init__.py]
 


### PR DESCRIPTION
Release for  no cache & clear all cache.

- convenience function to clear all caches in one. Closes #316.
```python
import pypyr.cache.admin as cache_admin

cache_admin.clear_all()
```
- disable caching entirely with new `no_cache` mode. Closes #317 
```python
from pypyr.config import config
from pypyr import pipelinerunner

# disable all caching
config.no_cache = True

# This will also NOT save `my-pipe` to cache once its loaded.
context = pipelinerunner.run(pipeline_name='my-pipe')
```