### PR TITLE
String Loader

### DIFF
--- a/pypyr/loaders/string.py
+++ b/pypyr/loaders/string.py
@@ -1,0 +1,33 @@
+"""Load pipelines from string."""
+import logging
+
+from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
+from pypyr.yaml import get_pipeline_yaml
+
+logger = logging.getLogger(__name__)
+
+
+def get_pipeline_definition(pipeline_name, parent=None):
+    """
+    Receives a pipeline as string, parses it and returns a PipelineDefinition.
+
+    Args:
+        pipeline_name (str): pipeline as string.
+        parent (Path-like): ignored
+
+    Returns:
+        PipelineDefinition describing the pipeline.
+            The dict parsed from the pipeline is in its .pipeline property.
+    """
+    logger.debug("starting")
+
+    pipeline = get_pipeline_yaml(pipeline_name)
+    info = PipelineFileInfo(
+        pipeline_name="", parent=parent, loader=__name__, path=None
+    )
+    definition = PipelineDefinition(pipeline=pipeline, info=info)
+
+    logger.debug("found %d stages in pipeline.", len(definition.pipeline))
+    logger.debug("done")
+
+    return definition

--- a/tests/integration/pypyr/loaders/string_loader_test.py
+++ b/tests/integration/pypyr/loaders/string_loader_test.py
@@ -1,0 +1,42 @@
+"""pypyr.loaders.string integration tests."""
+from textwrap import dedent
+
+from pypyr import pipelinerunner
+from pypyr.loaders.string import get_pipeline_definition
+
+
+def test_get_pipeline_definition():
+    """Test get_pipeline_definition."""
+    pipeline = dedent(
+        """\
+        steps:
+          - name: pypyr.steps.echo
+            in:
+              echoMe: 'testing'
+        """
+    )
+
+    definition = get_pipeline_definition(pipeline, None)
+
+    assert definition.pipeline == {
+        "steps": [{"name": "pypyr.steps.echo", "in": {"echoMe": "testing"}}]
+    }
+
+
+def test_run_with_custom_runner():
+    """Test run with custom string loader."""
+    pipeline = dedent(
+        """\
+        steps:
+          - name: pypyr.steps.set
+            in:
+              set:
+                test: 1
+        """
+    )
+
+    context = pipelinerunner.run(
+        pipeline_name=pipeline, loader="pypyr.loaders.string"
+    )
+
+    assert context["test"] == 1

--- a/tests/unit/pypyr/loaders/string__test.py
+++ b/tests/unit/pypyr/loaders/string__test.py
@@ -1,0 +1,25 @@
+"""pypyr.loaders.string unit tests."""
+from unittest.mock import patch
+
+import pypyr.loaders.string as string_loader
+from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
+
+
+@patch("ruamel.yaml.YAML.load", return_value="mocked pipeline def")
+def test_get_pipeline_definition(mocked_yaml):
+    """Unit test get_pipeline_definition."""
+    pipeline = "pipeline"
+
+    pipeline_def = string_loader.get_pipeline_definition(pipeline, None)
+
+    mocked_yaml.assert_called_once_with(pipeline)
+    expected_pipeline_def = PipelineDefinition(
+        "mocked pipeline def",
+        PipelineFileInfo(
+            pipeline_name="",
+            loader="pypyr.loaders.string",
+            parent=None,
+            path=None,
+        ),
+    )
+    assert pipeline_def == expected_pipeline_def


### PR DESCRIPTION
Adds the ability to load pipelines from a string instead of a file path. Useful for testing or for invoking the runner using a pipeline that doesn't come from the file system.