### PR TITLE
Bump version: 5.8.0 → 5.9.0

### DIFF
--- a/pypyr/__init__.py
+++ b/pypyr/__init__.py
@@ -5,6 +5,6 @@ NOTIFY (25) log level and notify() method to the global logger object.
 """
 import pypyr.log.logger
 
-__version__ = "5.8.0"
+__version__ = "5.9.0"
 
 pypyr.log.logger.set_up_notify_log_level()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.8.0
+current_version = 5.9.0
 
 [bumpversion:file:pypyr/__init__.py]
 


### PR DESCRIPTION
-  Adds a new string loader for pipelines - you can now load pipelines directly from a string.
-  Fixes issue with `!jsonify` custom tags failing to load with error "ruamel.yaml.constructor.ConstructorError: could not determine a constructor for the tag '!jsonify'" - this was due to a regression in the ruamel dependency