### PR TITLE
ruamel version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
   "python-dateutil",
-  "ruamel.yaml",
+  "ruamel.yaml >= 0.17.32",
   "tomli >= 1.1.0 ; python_version < '3.11'",
   "tomli-w",
 ]

--- a/pypyr/__init__.py
+++ b/pypyr/__init__.py
@@ -5,6 +5,6 @@ NOTIFY (25) log level and notify() method to the global logger object.
 """
 import pypyr.log.logger
 
-__version__ = "5.9.0"
+__version__ = "5.9.1"
 
 pypyr.log.logger.set_up_notify_log_level()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.9.0
+current_version = 5.9.1
 
 [bumpversion:file:pypyr/__init__.py]
 


### PR DESCRIPTION
To make sure installation get the latest ruamel dependency.

The code now depends on the newer 'RoundTripConstructor' object to have attribute 'construct_unknown'

Increase patch version to release this version dependency to pypi.