### PR TITLE
Models and loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "attrs",
+  "cattrs",
   "python-dateutil",
   "ruamel.yaml",
   "tomli >= 1.1.0 ; python_version < '3.11'",

--- a/pypyr/cache/loadercache.py
+++ b/pypyr/cache/loadercache.py
@@ -11,7 +11,7 @@ import pypyr.moduleloader
 from pypyr.cache.cache import Cache
 from pypyr.config import config
 from pypyr.errors import PipelineDefinitionError
-from pypyr.loaders.model import Pipeline
+from pypyr.models import Pipeline
 from pypyr.pipedef import PipelineDefinition, PipelineInfo
 
 logger = logging.getLogger(__name__)

--- a/pypyr/cache/loadercache.py
+++ b/pypyr/cache/loadercache.py
@@ -4,13 +4,14 @@ Attributes:
     loader_cache: Global instance of the loader cache.
                   Use this attribute to access the cache from elsewhere.
 """
-from collections.abc import Mapping
 import logging
+from collections.abc import Mapping
 
+import pypyr.moduleloader
 from pypyr.cache.cache import Cache
 from pypyr.config import config
 from pypyr.errors import PipelineDefinitionError
-import pypyr.moduleloader
+from pypyr.loaders.model import Pipeline
 from pypyr.pipedef import PipelineDefinition, PipelineInfo
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ class Loader():
         # if the pipeline is not a dict at top level, failures down-stream get
         # mysterious - this prevents malformed pipe from even making it into
         # cache.
-        if not isinstance(pipeline_definition.pipeline, Mapping):
+        if not isinstance(pipeline_definition.pipeline, (Mapping, Pipeline)):
             raise PipelineDefinitionError(
                 "A pipeline must be a mapping at the top level. "
                 "Does your top-level yaml have a 'steps:' key? "

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -11,7 +11,7 @@ from pypyr.config import config
 from pypyr.errors import (Call, ControlOfFlowInstruction, HandledError,
                           LoopMaxExhaustedError, PipelineDefinitionError, Stop,
                           get_error_name)
-from pypyr.loaders.model import Step as StepModel
+from pypyr.models import Step as StepModel
 from pypyr.utils import poll
 
 # use pypyr logger to ensure loglevel is set correctly

--- a/pypyr/dsl.py
+++ b/pypyr/dsl.py
@@ -393,7 +393,7 @@ class Step:
         self.run_me = step.run
         self.skip_me = step.skip
         self.swallow_me = step.swallow
-        self.on_error = step.onError
+        self.on_error = step.on_error
 
         self.foreach_items = step.foreach
 

--- a/pypyr/loaders/file.py
+++ b/pypyr/loaders/file.py
@@ -2,12 +2,12 @@
 import logging
 from pathlib import Path
 
+import pypyr.yaml
 from pypyr.cache.filecache import file_cache
 from pypyr.config import config
 from pypyr.errors import PipelineNotFoundError
 from pypyr.moduleloader import add_sys_path
 from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
-import pypyr.yaml
 
 logger = logging.getLogger(__name__)
 
@@ -153,8 +153,7 @@ def get_pipeline_definition(pipeline_name, parent):
         str(pipeline_path),
         lambda: load_pipeline_from_file(pipeline_path))
 
-    logger.debug("found %d stages in pipeline.",
-                 len(pipeline_definition.pipeline))
+    logger.debug("pipeline %s:", pipeline_definition.pipeline)
 
     logger.debug("done")
     return pipeline_definition
@@ -180,7 +179,7 @@ def load_pipeline_from_file(path):
 
     try:
         with open(path, encoding=config.default_encoding) as yaml_file:
-            pipeline_yaml = pypyr.yaml.get_pipeline_yaml(yaml_file)
+            pipeline = pypyr.yaml.get_pipeline(yaml_file)
     except FileNotFoundError:
         # this can only happen if file disappears between get_pipeline_path
         # & here, so pretty edge
@@ -198,8 +197,7 @@ def load_pipeline_from_file(path):
                             loader=__name__,
                             path=path)
 
-    pipeline_definition = PipelineDefinition(pipeline=pipeline_yaml,
-                                             info=info)
+    pipeline_definition = PipelineDefinition(pipeline=pipeline, info=info)
 
     logger.debug("done")
     return pipeline_definition

--- a/pypyr/loaders/model.py
+++ b/pypyr/loaders/model.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Optional, List
+
+from attrs import define
+
+from pypyr.pipedef import PipelineFileInfo, PipelineDefinition
+
+logger = logging.getLogger(__name__)
+
+
+@define
+class Step:
+    name: str
+    comment: Optional[str] = None
+    description: Optional[str] = None
+    foreach: Optional[list] = None
+    in_: Optional[dict] = None
+    onError: Optional[str] = None  # TODO
+    retry: Optional[dict] = None  # TODO
+    run: bool = True
+    skip: bool = False
+    swallow: bool = False
+    while_: Optional[dict] = None  # TODO
+
+
+@define
+class Pipeline:
+    context_parser: Optional[str] = None
+    steps: Optional[List[Step]] = None  # TODO
+    on_success: Optional[List[Step]] = None  # TODO
+    on_failure: Optional[List[Step]] = None  # TODO
+
+
+def get_pipeline_definition(pipeline_name, parent=None):
+    """
+    Receives a pipeline and returns a PipelineDefinition.
+
+    Args:
+        pipeline_name (Pipeline): pipeline.
+        parent (Path-like): ignored
+
+    Returns:
+        PipelineDefinition describing the pipeline.
+    """
+    logger.debug("starting")
+
+    info = PipelineFileInfo(
+        pipeline_name="", parent=parent, loader=__name__, path=None
+    )
+    definition = PipelineDefinition(pipeline=pipeline_name, info=info)
+
+    logger.debug("pipeline.", definition.pipeline)
+    logger.debug("done")
+
+    return definition

--- a/pypyr/loaders/model.py
+++ b/pypyr/loaders/model.py
@@ -1,54 +1,8 @@
 import logging
-from typing import List, Optional
-
-from attrs import define
 
 from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
 
 logger = logging.getLogger(__name__)
-
-
-@define
-class Step:
-    name: str
-    comment: Optional[str] = None
-    description: Optional[str] = None
-    foreach: Optional[list] = None
-    in_: Optional[dict] = None
-    onError: Optional[str] = None  # TODO
-    retry: Optional[dict] = None  # TODO
-    run: bool = True
-    skip: bool = False
-    swallow: bool = False
-    while_: Optional[dict] = None  # TODO
-
-    def __hash__(self):
-        # TODO: workaround to hash a pipeline
-        return id(self)
-
-
-@define
-class Pipeline:
-    context_parser: Optional[str] = None
-    steps: Optional[List[Step]] = None  # TODO
-    on_success: Optional[List[Step]] = None  # TODO
-    on_failure: Optional[List[Step]] = None  # TODO
-
-    def __hash__(self):
-        # TODO: workaround to hash a pipeline
-        return id(self)
-
-    def get(self, key, default=None):
-        # TODO: workaround to make the pipeline behave like a dict
-        return getattr(self, key, default)
-
-    def __getitem__(self, key):
-        # TODO: workaround to make the pipeline behave like a dict
-        return getattr(self, key)
-
-    def __contains__(self, item):
-        # TODO: workaround to make the pipeline behave like a dict
-        return hasattr(self, item)
 
 
 # TODO: rename pipeline_name to something else
@@ -57,7 +11,7 @@ def get_pipeline_definition(pipeline_name, parent=None):
     Receives a pipeline and returns a PipelineDefinition.
 
     Args:
-        pipeline_name (Pipeline): pipeline.
+        pipeline_name (pypyr.models.Pipeline): pipeline.
         parent (Path-like): ignored
 
     Returns:

--- a/pypyr/loaders/model.py
+++ b/pypyr/loaders/model.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Optional, List
+from typing import List, Optional
 
 from attrs import define
 
-from pypyr.pipedef import PipelineFileInfo, PipelineDefinition
+from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,10 @@ class Step:
     swallow: bool = False
     while_: Optional[dict] = None  # TODO
 
+    def __hash__(self):
+        # TODO: workaround to hash a pipeline
+        return id(self)
+
 
 @define
 class Pipeline:
@@ -30,7 +34,24 @@ class Pipeline:
     on_success: Optional[List[Step]] = None  # TODO
     on_failure: Optional[List[Step]] = None  # TODO
 
+    def __hash__(self):
+        # TODO: workaround to hash a pipeline
+        return id(self)
 
+    def get(self, key, default=None):
+        # TODO: workaround to make the pipeline behave like a dict
+        return getattr(self, key, default)
+
+    def __getitem__(self, key):
+        # TODO: workaround to make the pipeline behave like a dict
+        return getattr(self, key)
+
+    def __contains__(self, item):
+        # TODO: workaround to make the pipeline behave like a dict
+        return hasattr(self, item)
+
+
+# TODO: rename pipeline_name to something else
 def get_pipeline_definition(pipeline_name, parent=None):
     """
     Receives a pipeline and returns a PipelineDefinition.

--- a/pypyr/loaders/string.py
+++ b/pypyr/loaders/string.py
@@ -2,7 +2,7 @@
 import logging
 
 from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
-from pypyr.yaml import get_pipeline_yaml
+from pypyr.yaml import get_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -21,13 +21,13 @@ def get_pipeline_definition(pipeline_name, parent=None):
     """
     logger.debug("starting")
 
-    pipeline = get_pipeline_yaml(pipeline_name)
+    pipeline = get_pipeline(pipeline_name)
     info = PipelineFileInfo(
         pipeline_name="", parent=parent, loader=__name__, path=None
     )
     definition = PipelineDefinition(pipeline=pipeline, info=info)
 
-    logger.debug("found %d stages in pipeline.", len(definition.pipeline))
+    logger.debug("pipeline:", definition.pipeline)
     logger.debug("done")
 
     return definition

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -34,10 +34,10 @@ class Retry:
 
 @define
 class While:
-    error_on_max: bool = False
-    max: Optional[int] = None
-    sleep: float = 0
-    stop: Optional[str] = None
+    error_on_max: Evaluable[bool] = False
+    max: Optional[Evaluable[int]] = None
+    sleep: Evaluable[float] = 0
+    stop: Optional[Evaluable[str]] = None
 
 
 @define
@@ -110,7 +110,16 @@ def structure_evaluable(data, cls):
         return converter.structure(data, evaluable.supertype)
 
 
+def structure_bool(data, cls):
+    if not isinstance(data, bool):
+        raise ValueError(f'Expected a boolean value, got {data}')
+
+    return data
+
+
 converter.register_structure_hook(Pipeline, structure_pipeline)
+
+converter.register_structure_hook(bool, structure_bool)
 
 converter.register_structure_hook(Evaluable, structure_evaluable)
 

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -8,18 +8,26 @@ converter = Converter()
 
 
 @define
+class While:
+    error_on_max: bool = False
+    max: Optional[int] = None
+    sleep: float = 0
+    stop: Optional[str] = None
+
+
+@define
 class Step:
     name: str
     comment: Optional[str] = None
     description: Optional[str] = None
     foreach: Optional[list] = None
     in_: Optional[dict] = None
-    onError: Optional[str] = None  # TODO
+    on_error: Optional[str] = None
     retry: Optional[dict] = None  # TODO
     run: bool = True
     skip: bool = False
     swallow: bool = False
-    while_: Optional[dict] = None  # TODO
+    while_: Optional[While] = None
 
     def __hash__(self):
         # TODO: workaround to hash a pipeline
@@ -51,5 +59,22 @@ class Pipeline:
 
 
 converter.register_structure_hook(
-    Step, make_dict_structure_fn(Step, converter, in_=override(rename="in"))
+    Step,
+    make_dict_structure_fn(
+        Step,
+        converter,
+        on_error=override(rename="onError"),
+        in_=override(rename="in"),
+        while_=override(rename="while"),
+    ),
+)
+
+
+converter.register_structure_hook(
+    While,
+    make_dict_structure_fn(
+        While,
+        converter,
+        error_on_max=override(rename="errorOnMax"),
+    ),
 )

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+
+from attrs import define
+
+
+@define
+class Step:
+    name: str
+    comment: Optional[str] = None
+    description: Optional[str] = None
+    foreach: Optional[list] = None
+    in_: Optional[dict] = None
+    onError: Optional[str] = None  # TODO
+    retry: Optional[dict] = None  # TODO
+    run: bool = True
+    skip: bool = False
+    swallow: bool = False
+    while_: Optional[dict] = None  # TODO
+
+    def __hash__(self):
+        # TODO: workaround to hash a pipeline
+        return id(self)
+
+
+@define
+class Pipeline:
+    context_parser: Optional[str] = None
+    steps: Optional[List[Step]] = None  # TODO
+    on_success: Optional[List[Step]] = None  # TODO
+    on_failure: Optional[List[Step]] = None  # TODO
+
+    def __hash__(self):
+        # TODO: workaround to hash a pipeline
+        return id(self)
+
+    def get(self, key, default=None):
+        # TODO: workaround to make the pipeline behave like a dict
+        return getattr(self, key, default)
+
+    def __getitem__(self, key):
+        # TODO: workaround to make the pipeline behave like a dict
+        return getattr(self, key)
+
+    def __contains__(self, item):
+        # TODO: workaround to make the pipeline behave like a dict
+        return hasattr(self, item)

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -8,6 +8,18 @@ converter = Converter()
 
 
 @define
+class Retry:
+    backoff: str = 'fixed'
+    backoff_args: Optional[dict] = None
+    jrc: float = 0
+    max: Optional[int] = None
+    retry_on: Optional[List[str]] = None
+    sleep: float = 0
+    sleep_max: Optional[float] = None
+    stop_on: Optional[List[str]] = None
+
+
+@define
 class While:
     error_on_max: bool = False
     max: Optional[int] = None
@@ -23,7 +35,7 @@ class Step:
     foreach: Optional[list] = None
     in_: Optional[dict] = None
     on_error: Optional[str] = None
-    retry: Optional[dict] = None  # TODO
+    retry: Optional[Retry] = None
     run: bool = True
     skip: bool = False
     swallow: bool = False
@@ -56,6 +68,19 @@ class Pipeline:
     def __contains__(self, item):
         # TODO: workaround to make the pipeline behave like a dict
         return hasattr(self, item)
+
+
+converter.register_structure_hook(
+    Retry,
+    make_dict_structure_fn(
+        Retry,
+        converter,
+        backoff_args=override(rename="backoffArgs"),
+        retry_on=override(rename="retryOn"),
+        sleep_max=override(rename="sleepMax"),
+        stop_on=override(rename="stopOn"),
+    ),
+)
 
 
 converter.register_structure_hook(

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -1,6 +1,10 @@
 from typing import List, Optional
 
 from attrs import define
+from cattrs import Converter
+from cattrs.gen import make_dict_structure_fn, override
+
+converter = Converter()
 
 
 @define
@@ -44,3 +48,8 @@ class Pipeline:
     def __contains__(self, item):
         # TODO: workaround to make the pipeline behave like a dict
         return hasattr(self, item)
+
+
+converter.register_structure_hook(
+    Step, make_dict_structure_fn(Step, converter, in_=override(rename="in"))
+)

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -84,15 +84,15 @@ class Pipeline:
 
     def get(self, key, default=None):
         # TODO: workaround to make the pipeline behave like a dict
-        return getattr(self, key, default)
+        return getattr(self, key, (self.extra or {}).get(key, default))
 
     def __getitem__(self, key):
         # TODO: workaround to make the pipeline behave like a dict
-        return getattr(self, key)
+        return getattr(self, key, (self.extra or {}).get(key))
 
     def __contains__(self, item):
         # TODO: workaround to make the pipeline behave like a dict
-        return hasattr(self, item)
+        return hasattr(self, item) or item in self.extra
 
 
 def structure_pipeline(data, cls, extra_field_name='extra'):

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -49,9 +49,9 @@ class Step:
 @define
 class Pipeline:
     context_parser: Optional[str] = None
-    steps: Optional[List[Step]] = None  # TODO
-    on_success: Optional[List[Step]] = None  # TODO
-    on_failure: Optional[List[Step]] = None  # TODO
+    steps: Optional[List[Step | str]] = None
+    on_success: Optional[List[Step | str]] = None
+    on_failure: Optional[List[Step | str]] = None
 
     def __hash__(self):
         # TODO: workaround to hash a pipeline
@@ -68,6 +68,14 @@ class Pipeline:
     def __contains__(self, item):
         # TODO: workaround to make the pipeline behave like a dict
         return hasattr(self, item)
+
+
+converter.register_structure_hook(
+    Step | str,
+    lambda data, _: data
+    if isinstance(data, str)
+    else converter.structure(data, Step),
+)
 
 
 converter.register_structure_hook(

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -17,27 +17,27 @@ class Annotable(NewType):
         return Annotated[self, item]
 
 
-Evaluable = Annotable('Evaluable', str)
+Expression = Annotable('Expression', str)
 
 
 @define
 class Retry:
-    backoff: Evaluable[str] = 'fixed'
+    backoff: Expression[str] = 'fixed'
     backoff_args: Optional[dict] = None
-    jrc: Evaluable[float] = 0
-    max: Optional[Evaluable[int]] = None
+    jrc: Expression[float] = 0
+    max: Optional[Expression[int]] = None
     retry_on: Optional[List[str]] = None
-    sleep: Evaluable[float | List[float]] = 0
-    sleep_max: Optional[Evaluable[float]] = None
+    sleep: Expression[float | List[float]] = 0
+    sleep_max: Optional[Expression[float]] = None
     stop_on: Optional[List[str]] = None
 
 
 @define
 class While:
-    error_on_max: Evaluable[bool] = False
-    max: Optional[Evaluable[int]] = None
-    sleep: Evaluable[float] = 0
-    stop: Optional[Evaluable[str]] = None
+    error_on_max: Expression[bool] = False
+    max: Optional[Expression[int]] = None
+    sleep: Expression[float] = 0
+    stop: Optional[Expression[str]] = None
 
 
 @define
@@ -102,12 +102,12 @@ def structure_pipeline(data, cls, extra_field_name='extra'):
     return cls(**structured_data)
 
 
-def structure_evaluable(data, cls):
-    evaluable, type_ = get_args(cls)
+def structure_expression(data, cls):
+    expression, type_ = get_args(cls)
     try:
         return converter.structure(data, type_)
     except ValueError:
-        return converter.structure(data, evaluable.supertype)
+        return converter.structure(data, expression.supertype)
 
 
 def structure_bool(data, cls):
@@ -126,7 +126,7 @@ converter.register_structure_hook(
     lambda data, _: data if isinstance(data, list) else float(data),
 )
 
-converter.register_structure_hook(Evaluable, structure_evaluable)
+converter.register_structure_hook(Expression, structure_expression)
 
 converter.register_structure_hook(
     Step | str,

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -27,7 +27,7 @@ class Retry:
     jrc: Evaluable[float] = 0
     max: Optional[Evaluable[int]] = None
     retry_on: Optional[List[str]] = None
-    sleep: Evaluable[float] = 0
+    sleep: Evaluable[float | List[float]] = 0
     sleep_max: Optional[Evaluable[float]] = None
     stop_on: Optional[List[str]] = None
 
@@ -120,6 +120,11 @@ def structure_bool(data, cls):
 converter.register_structure_hook(Pipeline, structure_pipeline)
 
 converter.register_structure_hook(bool, structure_bool)
+
+converter.register_structure_hook(
+    float | List[float],
+    lambda data, _: data if isinstance(data, list) else float(data),
+)
 
 converter.register_structure_hook(Evaluable, structure_evaluable)
 

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -51,7 +51,7 @@ class Step:
     name: str
     comment: Optional[str] = None
     description: Optional[str] = None
-    foreach: Optional[list] = None
+    foreach: Optional[Tag[list]] = None
     in_: Optional[dict] = None
     on_error: Optional[str] = None
     retry: Optional[Retry] = None
@@ -130,9 +130,18 @@ def structure_bool(data, cls):
     return data
 
 
+def structure_list(data, cls):
+    if not isinstance(data, list):
+        raise ValueError(f'Expected a list value, got {data}')
+
+    return data
+
+
 converter.register_structure_hook(Pipeline, structure_pipeline)
 
 converter.register_structure_hook(bool, structure_bool)
+
+converter.register_structure_hook(list, structure_list)
 
 converter.register_structure_hook(
     float | List[float],

--- a/pypyr/models.py
+++ b/pypyr/models.py
@@ -55,9 +55,9 @@ class Step:
     in_: Optional[dict] = None
     on_error: Optional[str] = None
     retry: Optional[Retry] = None
-    run: bool = True
-    skip: bool = False
-    swallow: bool = False
+    run: Tag[bool] = True
+    skip: Tag[bool] = False
+    swallow: Tag[bool] = False
     while_: Optional[While] = None
 
     def __hash__(self):

--- a/pypyr/pipedef.py
+++ b/pypyr/pipedef.py
@@ -50,6 +50,14 @@ class PipelineDefinition():
         else:
             return False
 
+    def __repr__(self):
+        """Return repr(self)."""
+        return (
+            f"{self.__class__.__name__}("
+            f"pipeline={self.pipeline}, "
+            f"info={self.info})"
+        )
+
 
 class PipelineInfo():
     """The common attributes that every pipeline loader should set.

--- a/pypyr/stepsrunner.py
+++ b/pypyr/stepsrunner.py
@@ -46,28 +46,10 @@ class StepsRunner():
         """
         logger.debug("starting")
         assert step_group
-
         logger.debug("retrieving %s steps from pipeline", step_group)
         pipeline = self.pipeline_body
-        if step_group in pipeline:
-            steps = pipeline[step_group]
 
-            if steps is None:
-                logger.warning(
-                    "%s: sequence has no elements. So it won't do anything.",
-                    step_group,
-                )
-                logger.debug("done")
-                return None
-
-            steps_count = len(steps)
-
-            logger.debug("%s steps found under %s in pipeline definition.",
-                         steps_count, step_group)
-
-            logger.debug("done")
-            return steps
-        else:
+        if step_group not in pipeline:
             logger.debug(
                 "pipeline doesn't have a %(steps_group)s collection. Add a "
                 "%(steps_group)s: sequence to the yaml if you want "
@@ -76,6 +58,24 @@ class StepsRunner():
             )
             logger.debug("done")
             return None
+
+        steps = pipeline[step_group]
+
+        if steps is None:
+            logger.warning(
+                "%s: sequence has no elements. So it won't do anything.",
+                step_group,
+            )
+            logger.debug("done")
+            return None
+
+        steps_count = len(steps)
+
+        logger.debug("%s steps found under %s in pipeline definition.",
+                     steps_count, step_group)
+
+        logger.debug("done")
+        return steps
 
     def run_failure_step_group(self, group_name):
         """Run the group_name if it exists, as a failure handler..

--- a/pypyr/yaml.py
+++ b/pypyr/yaml.py
@@ -1,7 +1,13 @@
 """yaml handling functions."""
 import ruamel.yaml as yamler  # type: ignore
+
 from pypyr.context import Context
 from pypyr.dsl import Jsonify, PyString, SicString
+from pypyr.models import Pipeline, converter
+
+
+def get_pipeline(data):
+    return converter.structure(get_pipeline_yaml(data), Pipeline)
 
 
 def get_pipeline_yaml(file):

--- a/pypyr/yaml.py
+++ b/pypyr/yaml.py
@@ -7,7 +7,8 @@ from pypyr.models import Pipeline, converter
 
 
 def get_pipeline(data):
-    return converter.structure(get_pipeline_yaml(data), Pipeline)
+    yaml = get_pipeline_yaml(data)
+    return converter.structure(yaml, Pipeline)
 
 
 def get_pipeline_yaml(file):

--- a/tests/integration/pypyr/loaders/model_loader_test.py
+++ b/tests/integration/pypyr/loaders/model_loader_test.py
@@ -1,0 +1,38 @@
+"""pypyr.loaders.model integration tests."""
+
+from pypyr import pipelinerunner
+from pypyr.loaders.model import Pipeline, Step, get_pipeline_definition
+
+
+def test_get_pipeline_definition():
+    """Test get_pipeline_definition."""
+    pipeline = Pipeline(
+        steps=[
+            Step(
+                name="pypyr.steps.echo",
+                in_={"echoMe": "testing"},
+            )
+        ]
+    )
+
+    definition = get_pipeline_definition(pipeline, None)
+
+    assert definition.pipeline == pipeline
+
+
+def test_run_with_custom_runner():
+    """Test run with custom model loader."""
+    pipeline = Pipeline(
+        steps=[
+            Step(
+                name="pypyr.steps.set",
+                in_={"set": {"test": 1}},
+            )
+        ]
+    )
+
+    context = pipelinerunner.run(
+        pipeline_name=pipeline, loader="pypyr.loaders.model"
+    )
+
+    assert context["test"] == 1

--- a/tests/integration/pypyr/loaders/model_loader_test.py
+++ b/tests/integration/pypyr/loaders/model_loader_test.py
@@ -1,7 +1,8 @@
 """pypyr.loaders.model integration tests."""
 
 from pypyr import pipelinerunner
-from pypyr.loaders.model import Pipeline, Step, get_pipeline_definition
+from pypyr.loaders.model import get_pipeline_definition
+from pypyr.models import Pipeline, Step
 
 
 def test_get_pipeline_definition():

--- a/tests/integration/pypyr/loaders/string_loader_test.py
+++ b/tests/integration/pypyr/loaders/string_loader_test.py
@@ -20,7 +20,14 @@ def test_get_pipeline_definition():
     definition = get_pipeline_definition(pipeline, None)
 
     assert definition.pipeline == Pipeline(
-        steps=[Step(name="pypyr.steps.echo", in_={"echoMe": "testing"})]
+        steps=[
+            Step(
+                name="pypyr.steps.echo",
+                in_={"echoMe": "testing"},
+                line_col=5,
+                line_no=2,
+            )
+        ]
     )
 
 

--- a/tests/integration/pypyr/loaders/string_loader_test.py
+++ b/tests/integration/pypyr/loaders/string_loader_test.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 from pypyr import pipelinerunner
 from pypyr.loaders.string import get_pipeline_definition
+from pypyr.models import Pipeline, Step
 
 
 def test_get_pipeline_definition():
@@ -18,9 +19,9 @@ def test_get_pipeline_definition():
 
     definition = get_pipeline_definition(pipeline, None)
 
-    assert definition.pipeline == {
-        "steps": [{"name": "pypyr.steps.echo", "in": {"echoMe": "testing"}}]
-    }
+    assert definition.pipeline == Pipeline(
+        steps=[Step(name="pypyr.steps.echo", in_={"echoMe": "testing"})]
+    )
 
 
 def test_run_with_custom_runner():

--- a/tests/unit/pypyr/loaders/file_test.py
+++ b/tests/unit/pypyr/loaders/file_test.py
@@ -1,12 +1,13 @@
 """fileloader.py unit tests."""
 from pathlib import Path
-from unittest.mock import call, mock_open, patch, PropertyMock
+from unittest.mock import PropertyMock, call, mock_open, patch
 
 import pytest
 
 import pypyr.cache.admin
-from pypyr.errors import PipelineNotFoundError
 import pypyr.loaders.file as fileloader
+from pypyr.errors import PipelineNotFoundError
+from pypyr.models import Pipeline
 from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
 
 # region get_pipeline_path
@@ -161,7 +162,7 @@ def test_get_pipeline_path_raises_parent_is_cwd():
 
 
 @patch('pypyr.loaders.file.add_sys_path')
-@patch('ruamel.yaml.YAML.load', return_value='mocked pipeline def')
+@patch('ruamel.yaml.YAML.load', return_value={})
 @patch('pypyr.loaders.file.get_pipeline_path',
        return_value=Path('arb/path/x.yaml'))
 def test_get_pipeline_definition_pass(mocked_get_path,
@@ -176,7 +177,7 @@ def test_get_pipeline_definition_pass(mocked_get_path,
             'pipename', '/parent/dir')
 
     assert pipeline_def == PipelineDefinition(
-        'mocked pipeline def',
+        Pipeline(),
         PipelineFileInfo(pipeline_name='x.yaml',
                          loader='pypyr.loaders.file',
                          parent=Path('arb/path'),
@@ -194,7 +195,7 @@ def test_get_pipeline_definition_pass(mocked_get_path,
 
 
 @patch('pypyr.loaders.file.add_sys_path')
-@patch('ruamel.yaml.YAML.load', return_value='mocked pipeline def')
+@patch('ruamel.yaml.YAML.load', return_value={})
 @patch('pypyr.loaders.file.get_pipeline_path',
        return_value=Path('arb/path/x.yaml'))
 def test_get_pipeline_definition_clear_all_cache(mocked_get_path,
@@ -209,7 +210,7 @@ def test_get_pipeline_definition_clear_all_cache(mocked_get_path,
             'pipename', '/parent/dir')
 
     assert pipeline_def == PipelineDefinition(
-        'mocked pipeline def',
+        Pipeline(),
         PipelineFileInfo(pipeline_name='x.yaml',
                          loader='pypyr.loaders.file',
                          parent=Path('arb/path'),
@@ -228,7 +229,7 @@ def test_get_pipeline_definition_clear_all_cache(mocked_get_path,
 
 
 @patch('pypyr.loaders.file.add_sys_path')
-@patch('ruamel.yaml.YAML.load', return_value='mocked pipeline def')
+@patch('ruamel.yaml.YAML.load', return_value={})
 @patch('pypyr.loaders.file.get_pipeline_path',
        return_value=Path('arb/path/x.yaml'))
 def test_get_pipeline_definition_from_cache(mocked_get_path,
@@ -245,7 +246,7 @@ def test_get_pipeline_definition_from_cache(mocked_get_path,
             'pipename', '/parent/dir')
 
     assert pipeline_def_1 == pipeline_def_2 == PipelineDefinition(
-        'mocked pipeline def',
+        Pipeline(),
         PipelineFileInfo(pipeline_name='x.yaml',
                          loader='pypyr.loaders.file',
                          parent=Path('arb/path'),
@@ -268,7 +269,7 @@ def test_get_pipeline_definition_from_cache(mocked_get_path,
 
 
 @patch('pypyr.loaders.file.add_sys_path')
-@patch('ruamel.yaml.YAML.load', return_value='mocked pipeline def')
+@patch('ruamel.yaml.YAML.load', return_value={})
 @patch('pypyr.loaders.file.get_pipeline_path',
        return_value=Path('arb/path/x.yaml'))
 def test_get_pipeline_definition_with_encoding(mocked_get_path,
@@ -284,7 +285,7 @@ def test_get_pipeline_definition_with_encoding(mocked_get_path,
                 'pipename', '/parent/dir')
 
     assert pipeline_def == PipelineDefinition(
-        'mocked pipeline def',
+        Pipeline(),
         PipelineFileInfo(pipeline_name='x.yaml',
                          loader='pypyr.loaders.file',
                          parent=Path('arb/path'),

--- a/tests/unit/pypyr/loaders/model_test.py
+++ b/tests/unit/pypyr/loaders/model_test.py
@@ -1,0 +1,21 @@
+"""pypyr.loaders.model unit tests."""
+from pypyr.loaders.model import get_pipeline_definition, Pipeline
+from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
+
+
+def test_get_pipeline_definition():
+    """Unit test get_pipeline_definition."""
+    pipeline = Pipeline()
+
+    pipeline_def = get_pipeline_definition(pipeline, None)
+
+    expected_pipeline_def = PipelineDefinition(
+        pipeline,
+        PipelineFileInfo(
+            pipeline_name="",
+            loader="pypyr.loaders.model",
+            parent=None,
+            path=None,
+        ),
+    )
+    assert pipeline_def == expected_pipeline_def

--- a/tests/unit/pypyr/loaders/model_test.py
+++ b/tests/unit/pypyr/loaders/model_test.py
@@ -1,5 +1,6 @@
 """pypyr.loaders.model unit tests."""
-from pypyr.loaders.model import get_pipeline_definition, Pipeline
+from pypyr.loaders.model import get_pipeline_definition
+from pypyr.models import Pipeline
 from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
 
 

--- a/tests/unit/pypyr/loaders/string__test.py
+++ b/tests/unit/pypyr/loaders/string__test.py
@@ -2,10 +2,11 @@
 from unittest.mock import patch
 
 import pypyr.loaders.string as string_loader
+from pypyr.models import Pipeline
 from pypyr.pipedef import PipelineDefinition, PipelineFileInfo
 
 
-@patch("ruamel.yaml.YAML.load", return_value="mocked pipeline def")
+@patch("ruamel.yaml.YAML.load", return_value={})
 def test_get_pipeline_definition(mocked_yaml):
     """Unit test get_pipeline_definition."""
     pipeline = "pipeline"
@@ -14,7 +15,7 @@ def test_get_pipeline_definition(mocked_yaml):
 
     mocked_yaml.assert_called_once_with(pipeline)
     expected_pipeline_def = PipelineDefinition(
-        "mocked pipeline def",
+        Pipeline(),
         PipelineFileInfo(
             pipeline_name="",
             loader="pypyr.loaders.string",

--- a/tests/unit/pypyr/models/model_pipeline_test.py
+++ b/tests/unit/pypyr/models/model_pipeline_test.py
@@ -1,0 +1,65 @@
+from pypyr.models import Pipeline, Step, converter
+
+
+def test_init():
+    pipeline = Pipeline(
+        context_parser="context_parser",
+        steps=[Step(name='step')],
+        on_success=[Step(name='success')],
+        on_failure=[Step(name='failure')],
+    )
+
+    assert pipeline.context_parser == "context_parser"
+    assert pipeline.steps == [Step(name='step')]
+    assert pipeline.on_success == [Step(name='success')]
+    assert pipeline.on_failure == [Step(name='failure')]
+
+
+def test_init_with_steps_names():
+    pipeline = Pipeline(
+        context_parser="context_parser",
+        steps=['step'],
+        on_success=['success'],
+        on_failure=['failure'],
+    )
+
+    assert pipeline.context_parser == "context_parser"
+    assert pipeline.steps == ['step']
+    assert pipeline.on_success == ['success']
+    assert pipeline.on_failure == ['failure']
+
+
+def test_convert_steps_as_strings():
+    data = {
+        "context_parser": "context_parser",
+        "on_success": ["success_step"],
+        "on_failure": ["failure_step"],
+        "steps": ["step_one"],
+    }
+
+    pipeline = converter.structure(data, Pipeline)
+
+    assert pipeline == Pipeline(
+        context_parser="context_parser",
+        on_success=["success_step"],
+        on_failure=["failure_step"],
+        steps=["step_one"],
+    )
+
+
+def test_convert_with_steps():
+    data = {
+        "context_parser": "context_parser",
+        "on_success": [{"name": "success_step"}],
+        "on_failure": [{"name": "failure_step"}],
+        "steps": [{"name": "step_one"}],
+    }
+
+    pipeline = converter.structure(data, Pipeline)
+
+    assert pipeline == Pipeline(
+        context_parser="context_parser",
+        on_success=[Step(name="success_step")],
+        on_failure=[Step(name="failure_step")],
+        steps=[Step(name="step_one")],
+    )

--- a/tests/unit/pypyr/models/model_pipeline_test.py
+++ b/tests/unit/pypyr/models/model_pipeline_test.py
@@ -63,3 +63,23 @@ def test_convert_with_steps():
         on_failure=[Step(name="failure_step")],
         steps=[Step(name="step_one")],
     )
+
+
+def test_convert_with_custom_steps():
+    data = {
+        "my_custom_one": ["step_one"],
+        "my_custom_two": [{"name": "step_two"}],
+    }
+
+    pipeline = converter.structure(data, Pipeline)
+
+    assert pipeline.extra['my_custom_one'] == ["step_one"]
+    assert pipeline.extra['my_custom_two'] == [Step(name="step_two")]
+
+
+def test_extra_step():
+    data = {"extra": ["extra_step"]}
+
+    pipeline = converter.structure(data, Pipeline)
+
+    assert pipeline.extra['extra'] == ["extra_step"]

--- a/tests/unit/pypyr/models/model_retry_test.py
+++ b/tests/unit/pypyr/models/model_retry_test.py
@@ -1,0 +1,63 @@
+from decimal import Decimal
+
+from pypyr.models import Retry, converter
+
+
+def test_init_defaults():
+    retry = Retry()
+
+    assert retry.backoff == 'fixed'
+    assert retry.backoff_args is None
+    assert retry.jrc == 0
+    assert retry.max is None
+    assert retry.retry_on is None
+    assert retry.sleep == Decimal('0')
+    assert retry.sleep_max is None
+
+
+def test_init():
+    retry = Retry(
+        backoff="backoff",
+        backoff_args={"backoff": "args"},
+        jrc=1,
+        max=2,
+        retry_on=["retry", "on"],
+        sleep=3,
+        sleep_max=4,
+        stop_on=["stop", "on"],
+    )
+
+    assert retry.backoff == "backoff"
+    assert retry.backoff_args == {"backoff": "args"}
+    assert retry.jrc == 1
+    assert retry.max == 2
+    assert retry.retry_on == ["retry", "on"]
+    assert retry.sleep == Decimal('3')
+    assert retry.sleep_max == 4
+    assert retry.stop_on == ["stop", "on"]
+
+
+def test_convert():
+    data = {
+        'max': 1,
+        'sleep': 0,
+        'stopOn': ['ValueError', 'MyModule.SevereError'],
+        'retryOn': ['TimeoutError'],
+        'backoff': 'backoff',
+        'backoffArgs': {'arg1': 'value 1'},
+        'sleepMax': 123,
+        'jrc': 123.45,
+    }
+
+    retry = converter.structure(data, Retry)
+
+    assert retry == Retry(
+        backoff="backoff",
+        backoff_args={'arg1': 'value 1'},
+        jrc=123.45,
+        max=1,
+        retry_on=['TimeoutError'],
+        sleep=0,
+        sleep_max=123,
+        stop_on=['ValueError', 'MyModule.SevereError'],
+    )

--- a/tests/unit/pypyr/models/model_retry_test.py
+++ b/tests/unit/pypyr/models/model_retry_test.py
@@ -61,3 +61,27 @@ def test_convert():
         sleep_max=123,
         stop_on=['ValueError', 'MyModule.SevereError'],
     )
+
+
+def test_evaluable_fields():
+    """
+    Evaluable are types containing an expression
+    that can be formatted as the real value.
+    """
+    data = {
+        'backoff': '{backoff}',
+        'jrc': '{jrc}',
+        'max': '{max}',
+        'sleep': '{sleep}',
+        'sleepMax': '{sleepMax}',
+    }
+
+    retry = converter.structure(data, Retry)
+
+    assert retry == Retry(
+        backoff="{backoff}",
+        jrc='{jrc}',
+        max='{max}',
+        sleep='{sleep}',
+        sleep_max='{sleepMax}',
+    )

--- a/tests/unit/pypyr/models/model_retry_test.py
+++ b/tests/unit/pypyr/models/model_retry_test.py
@@ -85,3 +85,11 @@ def test_evaluable_fields():
         sleep='{sleep}',
         sleep_max='{sleepMax}',
     )
+
+
+def test_sleep_as_float_list():
+    data = {'sleep': [2, 4, 6]}
+
+    retry = converter.structure(data, Retry)
+
+    assert retry == Retry(sleep=[2, 4, 6])

--- a/tests/unit/pypyr/models/model_retry_test.py
+++ b/tests/unit/pypyr/models/model_retry_test.py
@@ -63,10 +63,9 @@ def test_convert():
     )
 
 
-def test_evaluable_fields():
+def test_expression_fields():
     """
-    Evaluable are types containing an expression
-    that can be formatted as the real value.
+    Expression is a type that can be formatted as the real value.
     """
     data = {
         'backoff': '{backoff}',

--- a/tests/unit/pypyr/models/model_retry_test.py
+++ b/tests/unit/pypyr/models/model_retry_test.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from pypyr.dsl import Jsonify, PyString, SicString
 from pypyr.models import Retry, converter
 
 
@@ -92,3 +93,23 @@ def test_sleep_as_float_list():
     retry = converter.structure(data, Retry)
 
     assert retry == Retry(sleep=[2, 4, 6])
+
+
+def test_special_tag_directive_fields():
+    data = {
+        'backoff': PyString('f()'),
+        'jrc': Jsonify("{'test': True}"),
+        'max': SicString('{max}'),
+        'sleep': SicString('{sleep}'),
+        'sleepMax': SicString('{sleepMax}'),
+    }
+
+    retry = converter.structure(data, Retry)
+
+    assert retry == Retry(
+        backoff=PyString('f()'),
+        jrc=Jsonify("{'test': True}"),
+        max=SicString('{max}'),
+        sleep=SicString('{sleep}'),
+        sleep_max=SicString('{sleepMax}'),
+    )

--- a/tests/unit/pypyr/models/model_step_test.py
+++ b/tests/unit/pypyr/models/model_step_test.py
@@ -1,3 +1,4 @@
+from pypyr.dsl import PyString
 from pypyr.models import Retry, Step, While, converter
 
 
@@ -84,8 +85,37 @@ def test_expression_fields():
     data = {
         'name': 'test',
         'foreach': '{foreach}',
+        'run': '{run}',
+        'skip': '{skip}',
+        'swallow': '{swallow}',
     }
 
     step = converter.structure(data, Step)
 
-    assert step == Step(name='test', foreach='{foreach}')
+    assert step == Step(
+        name='test',
+        foreach='{foreach}',
+        run='{run}',
+        skip='{skip}',
+        swallow='{swallow}',
+    )
+
+
+def test_special_tag_fields():
+    data = {
+        'name': 'test',
+        'foreach': PyString('[1,2,3]'),
+        'run': PyString('True'),
+        'skip': PyString('False'),
+        'swallow': PyString('False'),
+    }
+
+    step = converter.structure(data, Step)
+
+    assert step == Step(
+        name='test',
+        foreach=PyString('[1,2,3]'),
+        run=PyString('True'),
+        skip=PyString('False'),
+        swallow=PyString('False'),
+    )

--- a/tests/unit/pypyr/models/model_step_test.py
+++ b/tests/unit/pypyr/models/model_step_test.py
@@ -1,4 +1,4 @@
-from pypyr.models import Step, While, converter
+from pypyr.models import Retry, Step, While, converter
 
 
 def test_init():
@@ -10,7 +10,7 @@ def test_init():
         foreach=["foreach"],
         in_={"in": "in"},
         on_error="onError",
-        retry={"retry": "retry"},
+        retry=Retry(),
         run=True,
         skip=False,
         swallow=False,
@@ -23,7 +23,7 @@ def test_init():
     assert step.foreach == ["foreach"]
     assert step.in_ == {"in": "in"}
     assert step.on_error == "onError"
-    assert step.retry == {"retry": "retry"}
+    assert step.retry == Retry()
     assert step.run is True
     assert step.skip is False
     assert step.swallow is False
@@ -38,7 +38,16 @@ def test_convert():
         "foreach": ["foreach"],
         "in": {"in": "in"},
         "onError": "onError",
-        "retry": {"retry": "retry"},
+        "retry": {
+            'max': 1,
+            'sleep': 0,
+            'stopOn': ['ValueError', 'MyModule.SevereError'],
+            'retryOn': ['TimeoutError'],
+            'backoff': 'backoff',
+            'backoffArgs': {'arg1': 'value 1'},
+            'sleepMax': 123,
+            'jrc': 123.45,
+        },
         "run": True,
         "skip": False,
         "swallow": False,
@@ -54,7 +63,16 @@ def test_convert():
         foreach=["foreach"],
         in_={"in": "in"},
         on_error="onError",
-        retry={"retry": "retry"},
+        retry=Retry(
+            backoff="backoff",
+            backoff_args={'arg1': 'value 1'},
+            jrc=123.45,
+            max=1,
+            retry_on=['TimeoutError'],
+            sleep=0,
+            sleep_max=123,
+            stop_on=['ValueError', 'MyModule.SevereError'],
+        ),
         run=True,
         skip=False,
         swallow=False,

--- a/tests/unit/pypyr/models/model_step_test.py
+++ b/tests/unit/pypyr/models/model_step_test.py
@@ -1,0 +1,62 @@
+from pypyr.models import Step, While, converter
+
+
+def test_init():
+    """Step.__init__ happy path."""
+    step = Step(
+        name="blah",
+        comment="comment",
+        description="description",
+        foreach=["foreach"],
+        in_={"in": "in"},
+        on_error="onError",
+        retry={"retry": "retry"},
+        run=True,
+        skip=False,
+        swallow=False,
+        while_=While(),
+    )
+
+    assert step.name == "blah"
+    assert step.comment == "comment"
+    assert step.description == "description"
+    assert step.foreach == ["foreach"]
+    assert step.in_ == {"in": "in"}
+    assert step.on_error == "onError"
+    assert step.retry == {"retry": "retry"}
+    assert step.run is True
+    assert step.skip is False
+    assert step.swallow is False
+    assert step.while_ == While()
+
+
+def test_convert():
+    data = {
+        "name": "blah",
+        "comment": "comment",
+        "description": "description",
+        "foreach": ["foreach"],
+        "in": {"in": "in"},
+        "onError": "onError",
+        "retry": {"retry": "retry"},
+        "run": True,
+        "skip": False,
+        "swallow": False,
+        "while": {"stop": "stop", "max": 1, "sleep": 0.1, "errorOnMax": True},
+    }
+
+    step = converter.structure(data, Step)
+
+    assert step == Step(
+        name="blah",
+        comment="comment",
+        description="description",
+        foreach=["foreach"],
+        in_={"in": "in"},
+        on_error="onError",
+        retry={"retry": "retry"},
+        run=True,
+        skip=False,
+        swallow=False,
+        while_=While(stop="stop", max=1, sleep=0.1, error_on_max=True),
+    )

--- a/tests/unit/pypyr/models/model_step_test.py
+++ b/tests/unit/pypyr/models/model_step_test.py
@@ -78,3 +78,14 @@ def test_convert():
         swallow=False,
         while_=While(stop="stop", max=1, sleep=0.1, error_on_max=True),
     )
+
+
+def test_expression_fields():
+    data = {
+        'name': 'test',
+        'foreach': '{foreach}',
+    }
+
+    step = converter.structure(data, Step)
+
+    assert step == Step(name='test', foreach='{foreach}')

--- a/tests/unit/pypyr/models/model_while_test.py
+++ b/tests/unit/pypyr/models/model_while_test.py
@@ -31,3 +31,25 @@ def test_convert():
         sleep=0.1,
         error_on_max=True,
     )
+
+
+def test_evaluable_fields():
+    """
+    Evaluable are types containing an expression
+    that can be formatted as the real value.
+    """
+    data = {
+        'errorOnMax': '{errorOnMax}',
+        'max': '{max}',
+        'sleep': '{sleep}',
+        'stop': '{stop}',
+    }
+
+    retry = converter.structure(data, While)
+
+    assert retry == While(
+        error_on_max='{errorOnMax}',
+        max='{max}',
+        sleep='{sleep}',
+        stop='{stop}',
+    )

--- a/tests/unit/pypyr/models/model_while_test.py
+++ b/tests/unit/pypyr/models/model_while_test.py
@@ -1,3 +1,4 @@
+from pypyr.dsl import Jsonify, PyString, SicString
 from pypyr.models import While, converter
 
 
@@ -33,6 +34,24 @@ def test_convert():
     )
 
 
+def test_converter_cast_fields():
+    data = {
+        "stop": "stop",
+        "max": '1',
+        "sleep": '0.1',
+        "errorOnMax": True,
+    }
+
+    while_ = converter.structure(data, While)
+
+    assert while_ == While(
+        stop="stop",
+        max=1,
+        sleep=0.1,
+        error_on_max=True,
+    )
+
+
 def test_expression_fields():
     """
     Expresion is a type that can be formatted as the real value.
@@ -51,4 +70,22 @@ def test_expression_fields():
         max='{max}',
         sleep='{sleep}',
         stop='{stop}',
+    )
+
+
+def test_special_tag_directive_fields():
+    data = {
+        'errorOnMax': PyString('f()'),
+        'max': Jsonify("{'test': True}"),
+        'sleep': SicString('{sleep}'),
+        'stop': SicString('{stop}'),
+    }
+
+    while_ = converter.structure(data, While)
+
+    assert while_ == While(
+        error_on_max=PyString('f()'),
+        max=Jsonify("{'test': True}"),
+        sleep=SicString('{sleep}'),
+        stop=SicString('{stop}'),
     )

--- a/tests/unit/pypyr/models/model_while_test.py
+++ b/tests/unit/pypyr/models/model_while_test.py
@@ -33,10 +33,9 @@ def test_convert():
     )
 
 
-def test_evaluable_fields():
+def test_expression_fields():
     """
-    Evaluable are types containing an expression
-    that can be formatted as the real value.
+    Expresion is a type that can be formatted as the real value.
     """
     data = {
         'errorOnMax': '{errorOnMax}',

--- a/tests/unit/pypyr/models/model_while_test.py
+++ b/tests/unit/pypyr/models/model_while_test.py
@@ -1,0 +1,33 @@
+from pypyr.models import While, converter
+
+
+def test_init():
+    while_ = While(
+        stop="stop",
+        max=1,
+        sleep=0.1,
+        error_on_max=True,
+    )
+
+    assert while_.stop == "stop"
+    assert while_.max == 1
+    assert while_.sleep == 0.1
+    assert while_.error_on_max is True
+
+
+def test_convert():
+    data = {
+        "stop": "stop",
+        "max": 1,
+        "sleep": 0.1,
+        "errorOnMax": True,
+    }
+
+    while_ = converter.structure(data, While)
+
+    assert while_ == While(
+        stop="stop",
+        max=1,
+        sleep=0.1,
+        error_on_max=True,
+    )

--- a/tests/unit/pypyr/yaml_test.py
+++ b/tests/unit/pypyr/yaml_test.py
@@ -1,9 +1,33 @@
 """yaml.py unit tests."""
 import io
+from textwrap import dedent
+
 import pytest
 import ruamel.yaml as yamler
-from pypyr.context import Context
+
 import pypyr.yaml as pypyr_yaml
+from pypyr.context import Context
+from pypyr.models import Pipeline, Step
+
+
+# region get_pipeline
+def test_get_pipeline():
+    data = dedent(
+        """\
+        steps:
+          - name: pypyr.steps.echo
+            in:
+              echoMe: 'testing'
+          """
+    )
+    pipeline = pypyr_yaml.get_pipeline(data)
+
+    assert pipeline == Pipeline(
+        steps=[Step(name='pypyr.steps.echo', in_={'echoMe': 'testing'})]
+    )
+
+
+# endregion get_pipeline
 
 
 # region get_pipeline_yaml

--- a/tests/unit/pypyr/yaml_test.py
+++ b/tests/unit/pypyr/yaml_test.py
@@ -23,7 +23,14 @@ def test_get_pipeline():
     pipeline = pypyr_yaml.get_pipeline(data)
 
     assert pipeline == Pipeline(
-        steps=[Step(name='pypyr.steps.echo', in_={'echoMe': 'testing'})]
+        steps=[
+            Step(
+                name='pypyr.steps.echo',
+                in_={'echoMe': 'testing'},
+                line_col=5,
+                line_no=2,
+            )
+        ]
     )
 
 


### PR DESCRIPTION
This PR is a proposal (and still a draft).

The proposal is to add models to:
1. Improve Pipeline validations (related to #116 and #229).
2. Declare Pipelines using Python (examples on `tests/integration/pypyr/loaders/model_loader_test.py`) instead of YAML.

@yaythomas, please take a look and let me know if this proposal makes sense for the project. If so we can work together to improve the draft and merge it.

If it makes sense to the project, my idea is to split it into two improvements:
1. Add the ability to use Python objects to define Pipelines without breaking changes.
2. Unify new models and DSL classes. It will have breaking changes.